### PR TITLE
feat: Implement ViewModel for signup and Calendar picker

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -69,6 +69,7 @@ kotlin {
             implementation(libs.koin.core)
             implementation(libs.koin.compose)
             implementation(libs.koin.compose.viewmodel)
+            implementation(libs.kotlinx.datetime)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -27,4 +27,6 @@
     <string name="signup_form_register_label">Register</string>
 
     <string name="general_label_or">Or</string>
+    <string name="general_label_ok">Ok</string>
+    <string name="general_label_cancel">Cancel</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
@@ -10,6 +10,7 @@ import us.docbee.docbeeapp.domain.repositories.EmailAuthRepository
 import us.docbee.docbeeapp.domain.usecases.EmailAuthUseCase
 import us.docbee.docbeeapp.domain.usecases.EmailSignupUseCase
 import us.docbee.docbeeapp.presentation.login.LoginViewModel
+import us.docbee.docbeeapp.presentation.login.SignupViewModel
 
 val dataSourcesModule = module {
     factory<EmailAuth> { getEmailAuth() }
@@ -26,6 +27,7 @@ val usesCasesModule = module {
 
 val viewModelsModule = module {
     viewModelOf(::LoginViewModel)
+    viewModelOf(::SignupViewModel)
 }
 
 fun initKoin() {

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/inputs/InputDateFieldText.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/inputs/InputDateFieldText.kt
@@ -1,0 +1,173 @@
+package us.docbee.docbeeapp.presentation.components.inputs
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DatePickerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.unit.dp
+import docbee.composeapp.generated.resources.Res
+import docbee.composeapp.generated.resources.general_label_cancel
+import docbee.composeapp.generated.resources.general_label_ok
+import docbee.composeapp.generated.resources.ic_calendar
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.resources.vectorResource
+import us.docbee.docbeeapp.presentation.theme.Black100
+import us.docbee.docbeeapp.presentation.theme.Blue100
+import us.docbee.docbeeapp.presentation.theme.Gray
+import us.docbee.docbeeapp.presentation.theme.Gray300
+import us.docbee.docbeeapp.presentation.theme.Gray400
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InputDateFieldText(
+    modifier: Modifier = Modifier,
+    value: String,
+    inputLabel: String,
+    datePickerState: DatePickerState,
+    isError: Boolean = false,
+    errorLabel: String = "",
+    onAcceptFocusDirection: FocusDirection = FocusDirection.Down,
+    onCancelFocusDirection: FocusDirection = FocusDirection.Up,
+    onSelectedDate: (Long) -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val focusRequester = remember { FocusRequester() }
+    var hasFocus by remember { mutableStateOf(false) }
+    var selectedDate by remember { mutableStateOf<Long?>(null) }
+    var showModal by remember { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
+
+    LaunchedEffect(interactionSource) {
+        interactionSource.interactions.collect { interaction ->
+            if (interaction is PressInteraction.Release) {
+                showModal = true
+            }
+        }
+    }
+
+    Box(modifier = Modifier) {
+        Column(modifier = modifier.fillMaxWidth()) {
+            Text(
+                modifier = Modifier.padding(vertical = 4.dp),
+                text = inputLabel,
+                style = MaterialTheme.typography.labelMedium,
+                color = if (isError) MaterialTheme.colorScheme.error else Gray
+            )
+            OutlinedTextField(
+                modifier = modifier.fillMaxWidth()
+                    .focusRequester(focusRequester)
+                    .onFocusChanged { focusState ->
+                        if (focusState.isFocused && !hasFocus) {
+                            showModal = true
+                            hasFocus = true
+                        }
+                        if (!focusState.isFocused) {
+                            hasFocus = false
+                        }
+                    },
+                value = value,
+                onValueChange = { },
+                colors = OutlinedTextFieldDefaults.colors(
+                    unfocusedBorderColor = Gray300,
+                    focusedBorderColor = Blue100,
+                    focusedTextColor = Black100,
+                    unfocusedTextColor = Black100
+                ),
+                textStyle = MaterialTheme.typography.bodyMedium,
+                shape = RoundedCornerShape(10.dp),
+                interactionSource = interactionSource,
+                readOnly = true,
+                trailingIcon = {
+                    Image(
+                        modifier = Modifier.size(16.dp),
+                        imageVector = vectorResource(Res.drawable.ic_calendar),
+                        colorFilter = ColorFilter.tint(color = Gray400),
+                        contentDescription = null
+                    )
+                },
+                supportingText = {
+                    if (isError && errorLabel.isNotEmpty()) {
+                        Text(
+                            text = errorLabel,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            )
+        }
+
+        if (showModal) {
+            DatePickerDialog(
+                onDismissRequest = { showModal = false },
+                confirmButton = {
+                    DatePickerButtons(
+                        text = stringResource(Res.string.general_label_ok),
+                        onClick = {
+                            selectedDate = datePickerState.selectedDateMillis
+                            selectedDate?.let { onSelectedDate(it) }
+                            showModal = false
+                            focusManager.moveFocus(onAcceptFocusDirection)
+                        }
+                    )
+                },
+                dismissButton = {
+                    DatePickerButtons(
+                        text = stringResource(Res.string.general_label_cancel),
+                        onClick = {
+                            showModal = false
+                            focusManager.moveFocus(onCancelFocusDirection)
+                        }
+                    )
+                }
+            ) {
+                DatePicker(
+                    state = datePickerState,
+                    modifier = Modifier.sizeIn(maxWidth = 350.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun DatePickerButtons(
+    text: String,
+    onClick: () -> Unit
+) {
+    TextButton(onClick = onClick) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.titleMedium,
+            color = Gray
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/AuthScreen.kt
@@ -130,8 +130,8 @@ fun AuthScreenContent(
             )
             SignupScreen(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 42.dp),
-                isSignupTabbed = !isLoginTab,
-                onClick = { }
+                snackbarState = snackbarState,
+                isSignupTabbed = !isLoginTab
             )
             LoginSocialButtons(modifier = Modifier.fillMaxWidth().padding(horizontal = 42.dp))
         }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/SignupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/SignupScreen.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
@@ -17,7 +19,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import docbee.composeapp.generated.resources.Res
-import docbee.composeapp.generated.resources.ic_calendar
 import docbee.composeapp.generated.resources.signup_form_birth_date_field
 import docbee.composeapp.generated.resources.signup_form_email_field
 import docbee.composeapp.generated.resources.signup_form_lastname_field
@@ -25,25 +26,87 @@ import docbee.composeapp.generated.resources.signup_form_name_field
 import docbee.composeapp.generated.resources.signup_form_password_field
 import docbee.composeapp.generated.resources.signup_form_phone_field
 import docbee.composeapp.generated.resources.signup_form_register_label
+import kotlinx.coroutines.flow.collectLatest
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.resources.vectorResource
+import org.koin.compose.viewmodel.koinViewModel
 import us.docbee.docbeeapp.presentation.components.PrimaryButton
+import us.docbee.docbeeapp.presentation.components.inputs.InputDateFieldText
 import us.docbee.docbeeapp.presentation.components.inputs.InputFieldText
 import us.docbee.docbeeapp.presentation.components.inputs.InputPasswordFieldText
+import us.docbee.docbeeapp.presentation.login.effects.SignupEffect
+import us.docbee.docbeeapp.presentation.login.events.SignupEvents
+import us.docbee.docbeeapp.presentation.login.states.SignupState
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SignupScreen(
     modifier: Modifier = Modifier,
+    snackbarState: SnackbarHostState,
     isSignupTabbed: Boolean,
-    onClick: () -> Unit = { }
+    viewModel: SignupViewModel = koinViewModel()
 ) {
-    var nameField by remember { mutableStateOf("") }
-    var lastNameField by remember { mutableStateOf("") }
-    var emailField by remember { mutableStateOf("") }
-    var dateOfBirthField by remember { mutableStateOf("") }
-    var phoneNumberField by remember { mutableStateOf("") }
-    var passwordField by remember { mutableStateOf("") }
-    if (!isSignupTabbed) return
+    val state = viewModel.state.collectAsState()
+
+    LaunchedEffect(!isSignupTabbed) {
+        viewModel.onEvent(SignupEvents.OnResetEvent)
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.effect.collectLatest { effect ->
+            when (effect) {
+                is SignupEffect.ShowErrorMessage -> {
+                    snackbarState.showSnackbar(
+                        message = effect.error,
+                        duration = SnackbarDuration.Short
+                    )
+                }
+
+                is SignupEffect.NavigateToDashboard -> Unit
+            }
+        }
+    }
+    if (isSignupTabbed) {
+        SignupContainer(
+            modifier = modifier,
+            uiState = state.value,
+            onChangeName = { name ->
+                viewModel.onEvent(SignupEvents.OnChangeNameField(name))
+            },
+            onChangeLastName = { lastname ->
+                viewModel.onEvent(SignupEvents.OnChangeLastNameField(lastname))
+            },
+            onChangeEmail = { email ->
+                viewModel.onEvent(SignupEvents.OnChangeEmailField(email))
+            },
+            onChangeDateOfBirth = { dateOfBirth ->
+                viewModel.onEvent(SignupEvents.OnChangeDateOfBirthField(dateOfBirth))
+            },
+            onChangePhoneNumber = { phoneNumber ->
+                viewModel.onEvent(SignupEvents.OnChangePhoneNumberField(phoneNumber))
+            },
+            onChangePassword = { password ->
+                viewModel.onEvent(SignupEvents.OnChangePasswordField(password))
+            },
+            onSignupClick = {
+                viewModel.onEvent(SignupEvents.OnSignupClickButton)
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SignupContainer(
+    modifier: Modifier = Modifier,
+    uiState: SignupState,
+    onChangeName: (String) -> Unit,
+    onChangeLastName: (String) -> Unit,
+    onChangeEmail: (String) -> Unit,
+    onChangeDateOfBirth: (Long) -> Unit,
+    onChangePhoneNumber: (String) -> Unit,
+    onChangePassword: (String) -> Unit,
+    onSignupClick: () -> Unit,
+) {
     Column(modifier = modifier) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -55,8 +118,8 @@ fun SignupScreen(
                 keyboardCapitalization = KeyboardCapitalization.Words,
                 focusDirection = FocusDirection.Right,
                 imeAction = ImeAction.Next,
-                value = nameField,
-                onValueChange = { nameField = it }
+                value = uiState.name,
+                onValueChange = onChangeName
             )
             InputFieldText(
                 modifier = Modifier.weight(1f),
@@ -64,8 +127,8 @@ fun SignupScreen(
                 keyboardCapitalization = KeyboardCapitalization.Words,
                 focusDirection = FocusDirection.Down,
                 imeAction = ImeAction.Next,
-                value = lastNameField,
-                onValueChange = { lastNameField = it }
+                value = uiState.lastName,
+                onValueChange = onChangeLastName
             )
         }
         Spacer(modifier = Modifier.height(16.dp))
@@ -73,37 +136,35 @@ fun SignupScreen(
             inputLabel = stringResource(Res.string.signup_form_email_field),
             focusDirection = FocusDirection.Down,
             imeAction = ImeAction.Next,
-            value = emailField,
-            onValueChange = { emailField = it }
+            value = uiState.email,
+            onValueChange = onChangeEmail
         )
         Spacer(modifier = Modifier.height(16.dp))
-        InputFieldText(
+        InputDateFieldText(
+            value = uiState.dateOfBirth,
             inputLabel = stringResource(Res.string.signup_form_birth_date_field),
-            trailingIcon = vectorResource(Res.drawable.ic_calendar),
-            focusDirection = FocusDirection.Down,
-            imeAction = ImeAction.Next,
-            value = dateOfBirthField,
-            onValueChange = { dateOfBirthField = it }
+            datePickerState = rememberDatePickerState(),
+            onSelectedDate = onChangeDateOfBirth
         )
         Spacer(modifier = Modifier.height(16.dp))
         InputFieldText(
             inputLabel = stringResource(Res.string.signup_form_phone_field),
             focusDirection = FocusDirection.Down,
             imeAction = ImeAction.Next,
-            value = phoneNumberField,
-            onValueChange = { phoneNumberField = it }
+            value = uiState.phoneNumber,
+            onValueChange = onChangePhoneNumber
         )
         Spacer(modifier = Modifier.height(16.dp))
         InputPasswordFieldText(
             inputLabel = stringResource(Res.string.signup_form_password_field),
-            value = passwordField,
-            onValueChange = { passwordField = it },
+            value = uiState.password,
+            onValueChange = onChangePassword,
             imeAction = ImeAction.Done
         )
         Spacer(modifier = Modifier.height(24.dp))
         PrimaryButton(
             text = stringResource(Res.string.signup_form_register_label),
-            onClick = onClick
+            onClick = onSignupClick
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/SignupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/SignupViewModel.kt
@@ -1,0 +1,78 @@
+package us.docbee.docbeeapp.presentation.login
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import us.docbee.docbeeapp.domain.usecases.EmailSignupUseCase
+import us.docbee.docbeeapp.presentation.login.effects.SignupEffect
+import us.docbee.docbeeapp.presentation.login.events.SignupEvents
+import us.docbee.docbeeapp.presentation.login.states.SignupState
+import us.docbee.docbeeapp.utils.convertMillisWithoutTimeZone
+
+class SignupViewModel(
+    private val signupUseCase: EmailSignupUseCase
+) : ViewModel() {
+
+    private var _state: MutableStateFlow<SignupState> = MutableStateFlow(SignupState())
+    val state: StateFlow<SignupState> = _state
+
+    private var _effect: MutableSharedFlow<SignupEffect> = MutableSharedFlow()
+    val effect: SharedFlow<SignupEffect> = _effect
+
+    fun onEvent(event: SignupEvents) {
+        when (event) {
+            is SignupEvents.OnChangeNameField -> onChangeName(event.name)
+            is SignupEvents.OnChangeLastNameField -> onChangeLastName(event.lastName)
+            is SignupEvents.OnChangeEmailField -> onChangeEmail(event.email)
+            is SignupEvents.OnChangeDateOfBirthField -> onChangeDateOfBirth(event.dateOfBirth)
+            is SignupEvents.OnChangePhoneNumberField -> onChangePhoneNumber(event.phoneNumber)
+            is SignupEvents.OnChangePasswordField -> onChangePassword(event.password)
+            is SignupEvents.OnResetEvent -> onResetData()
+            is SignupEvents.OnSignupClickButton -> performSignup()
+        }
+    }
+
+    private fun onChangeName(name: String) {
+        _state.value = _state.value.copy(name = name)
+    }
+
+    private fun onChangeLastName(lastName: String) {
+        _state.value = _state.value.copy(lastName = lastName)
+    }
+
+    private fun onChangeEmail(email: String) {
+        _state.value = _state.value.copy(email = email)
+    }
+
+    private fun onChangeDateOfBirth(dateOfBirth: Long) {
+        val dateOfBirthFormatted = convertMillisWithoutTimeZone(dateOfBirth)
+        _state.value = _state.value.copy(dateOfBirth = dateOfBirthFormatted)
+    }
+
+    private fun onChangePhoneNumber(phoneNumber: String) {
+        _state.value = _state.value.copy(phoneNumber = phoneNumber)
+    }
+
+    private fun onChangePassword(password: String) {
+        _state.value = _state.value.copy(password = password)
+    }
+
+    private fun onResetData() {
+        _state.value = SignupState()
+    }
+
+    private fun performSignup() {
+
+    }
+
+    private fun sendEffect(effect: SignupEffect) {
+        viewModelScope.launch {
+            _effect.emit(effect)
+        }
+    }
+
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/effects/SignupEffect.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/effects/SignupEffect.kt
@@ -1,0 +1,6 @@
+package us.docbee.docbeeapp.presentation.login.effects
+
+sealed class SignupEffect {
+    data class ShowErrorMessage(val error: String): SignupEffect()
+    data object NavigateToDashboard: SignupEffect()
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/events/SignupEvents.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/events/SignupEvents.kt
@@ -1,0 +1,12 @@
+package us.docbee.docbeeapp.presentation.login.events
+
+sealed class SignupEvents {
+    data class OnChangeNameField(val name: String): SignupEvents()
+    data class OnChangeLastNameField(val lastName: String): SignupEvents()
+    data class OnChangeEmailField(val email: String): SignupEvents()
+    data class OnChangeDateOfBirthField(val dateOfBirth: Long): SignupEvents()
+    data class OnChangePhoneNumberField(val phoneNumber: String): SignupEvents()
+    data class OnChangePasswordField(val password: String): SignupEvents()
+    data object OnResetEvent: SignupEvents()
+    data object OnSignupClickButton: SignupEvents()
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/states/SignupState.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/states/SignupState.kt
@@ -1,0 +1,10 @@
+package us.docbee.docbeeapp.presentation.login.states
+
+data class SignupState(
+    var name: String = "",
+    var lastName: String = "",
+    var email: String = "",
+    var dateOfBirth: String = "",
+    var phoneNumber: String = "",
+    var password: String = ""
+)

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/utils/DateTransformationsUtils.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/utils/DateTransformationsUtils.kt
@@ -1,0 +1,16 @@
+package us.docbee.docbeeapp.utils
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+fun convertMillisWithoutTimeZone(millis: Long): String {
+    val instant = Instant.fromEpochMilliseconds(millis)
+    val localDate = instant.toLocalDateTime(TimeZone.UTC).date
+
+    val day = localDate.dayOfMonth.toString().padStart(2, '0')
+    val month = localDate.monthNumber.toString().padStart(2, '0')
+    val year = localDate.year
+
+    return "$year / $month / $day"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,8 @@ junit = "4.13.2"
 kotlin = "2.2.0"
 firebase = "33.16.0"
 google-services = "4.4.2"
-koin="4.0.3"
+koin = "4.0.3"
+kotlin-datetime = "0.6.2"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -35,6 +36,7 @@ koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koin"}
 koin-core = { group = "io.insert-koin", name = "koin-core" }
 koin-compose = { group = "io.insert-koin", name = "koin-compose" }
 koin-compose-viewmodel = { group = "io.insert-koin", name = "koin-compose-viewmodel" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlin-datetime"}
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
# Add DatePickerField and Move Form Data to ViewModel

## Description

This PR introduces:

- ✅ A **InputDateFieldText** component that opens the calendar for selecting dates
    - Provides a user-friendly way to pick a date from a calendar UI
    - Displays the selected date in the field
- ✅ Refactoring:
    - Moved form data handling logic from UI layer into the corresponding **ViewModel -> SignupViewModel **
    - Improves separation of concerns and maintainability

## Visual Evidence

Android

https://github.com/user-attachments/assets/69565a4d-61e5-4b22-b9a1-537e98ab0bfa

iOS

https://github.com/user-attachments/assets/98712a4a-b7a5-47ad-bfe6-ad99c62501af

