### PR TITLE
feat: Add navigator to app

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -76,6 +76,7 @@ kotlin {
             implementation(libs.coil.compose.network)
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.serialization)
+            implementation(libs.androidx.navigation)
         }
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/App.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
-import us.docbee.docbeeapp.presentation.login.AuthScreen
+import us.docbee.docbeeapp.presentation.navigation.AppNavigator
 
 @Composable
 @Preview
@@ -17,7 +17,7 @@ fun App() {
             modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            AuthScreen()
+            AppNavigator()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/AuthScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import docbee.composeapp.generated.resources.Res
 import docbee.composeapp.generated.resources.compose_multiplatform
 import docbee.composeapp.generated.resources.general_label_or
@@ -57,7 +58,7 @@ import us.docbee.docbeeapp.presentation.theme.Gray200
 import us.docbee.docbeeapp.presentation.theme.White
 
 @Composable
-fun AuthScreen() {
+fun AuthScreen(navController: NavController) {
     var isLoginTabSelected by remember { mutableStateOf(true) }
     var snackbarHostState = remember { SnackbarHostState() }
 

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/AppNavigator.kt
@@ -1,0 +1,18 @@
+package us.docbee.docbeeapp.presentation.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+
+import androidx.navigation.compose.rememberNavController
+import us.docbee.docbeeapp.presentation.navigation.routes.addLoginNav
+
+@Composable
+fun AppNavigator() {
+    val navController = rememberNavController()
+    NavHost(
+        navController = navController,
+        startDestination = AuthenticationRoute
+    ) {
+        addLoginNav(navController)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/NavigationRoutes.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/NavigationRoutes.kt
@@ -1,0 +1,6 @@
+package us.docbee.docbeeapp.presentation.navigation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object AuthenticationRoute

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/routes/AuthenticationRoute.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/routes/AuthenticationRoute.kt
@@ -1,0 +1,13 @@
+package us.docbee.docbeeapp.presentation.navigation.routes
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import us.docbee.docbeeapp.presentation.login.AuthScreen
+import us.docbee.docbeeapp.presentation.navigation.AuthenticationRoute
+
+fun NavGraphBuilder.addLoginNav(navController: NavController) {
+    composable<AuthenticationRoute> {
+        AuthScreen(navController)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,10 +15,11 @@ junit = "4.13.2"
 kotlin = "2.2.0"
 firebase = "33.16.0"
 google-services = "4.4.2"
-koin = "4.0.3"
+koin = "4.1.0"
 kotlin-datetime = "0.6.2"
 coil = "3.2.0"
 ktor = "3.2.1"
+navigation = "2.9.0-beta03"
 
 
 [libraries]
@@ -40,13 +41,13 @@ koin-core = { group = "io.insert-koin", name = "koin-core" }
 koin-compose = { group = "io.insert-koin", name = "koin-compose" }
 koin-compose-viewmodel = { group = "io.insert-koin", name = "koin-compose-viewmodel" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlin-datetime"}
-kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlin" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-compose-network = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-serialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+androidx-navigation = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigation" }
 
 
 [plugins]


### PR DESCRIPTION
# Add AppNavigator with NavHost, Routes, and Destinations

## Description

This PR introduces the base navigation architecture to the app:

- ✅ Created `AppNavigator` as a centralized entry point for in-app navigation
- ✅ Set up `NavHost` to manage screen transitions
- ✅ Defined route structure and destinations, including:
    - AuthenticationRoute
- ✅ Navigation logic is now decoupled and scalable for future features

## Visual Evidence
<img width="724" height="764" alt="image" src="https://github.com/user-attachments/assets/c0361ca3-1f56-493f-8a5b-6d37556a8361" />
