### PR TITLE
feature: Implement firestore for saving users

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
             implementation(libs.androidx.activity.compose)
             implementation(project.dependencies.platform(libs.firebase.bom))
             implementation(libs.firebase.auth)
+            implementation(libs.firebase.firestore)
             implementation(libs.ktor.client.okhttp)
         }
         commonMain.dependencies {

--- a/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/data/datasources/UserRemoteDataSource.android.kt
+++ b/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/data/datasources/UserRemoteDataSource.android.kt
@@ -1,0 +1,19 @@
+package us.docbee.docbeeapp.data.datasources
+
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+import us.docbee.docbeeapp.domain.mappers.toMap
+import us.docbee.docbeeapp.domain.models.user.UserProfile
+import us.docbee.docbeeapp.utils.FIRESTORE_COLLECTION_USER
+
+class AndroidUserRemoteDataSource : UserRemoteDataSource {
+    override suspend fun saveUser(profile: UserProfile) {
+        FirebaseFirestore.getInstance()
+            .collection(FIRESTORE_COLLECTION_USER)
+            .document(profile.uid)
+            .set(profile.toMap())
+            .await()
+    }
+}
+
+actual fun getUserDataSource(): UserRemoteDataSource = AndroidUserRemoteDataSource()

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/datasources/UserRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/datasources/UserRemoteDataSource.kt
@@ -1,0 +1,9 @@
+package us.docbee.docbeeapp.data.datasources
+
+import us.docbee.docbeeapp.domain.models.user.UserProfile
+
+interface UserRemoteDataSource {
+    suspend fun saveUser(profile: UserProfile)
+}
+
+expect fun getUserDataSource(): UserRemoteDataSource

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/repositories/UserDataRepository.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/repositories/UserDataRepository.kt
@@ -1,0 +1,13 @@
+package us.docbee.docbeeapp.data.repositories
+
+import us.docbee.docbeeapp.data.datasources.UserRemoteDataSource
+import us.docbee.docbeeapp.domain.models.user.UserProfile
+import us.docbee.docbeeapp.domain.repositories.UserRepository
+
+class UserDataRepository(
+    private val userDataSource: UserRemoteDataSource
+): UserRepository {
+    override suspend fun saveUserProfile(profile: UserProfile) {
+        userDataSource.saveUser(profile)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
@@ -5,12 +5,16 @@ import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 import us.docbee.docbeeapp.data.EmailAuth
 import us.docbee.docbeeapp.data.datasources.JsonResourceLoader
+import us.docbee.docbeeapp.data.datasources.UserRemoteDataSource
+import us.docbee.docbeeapp.data.datasources.getUserDataSource
 import us.docbee.docbeeapp.data.datasources.interfaces.ResourcesLoader
 import us.docbee.docbeeapp.data.getEmailAuth
 import us.docbee.docbeeapp.data.repositories.EmailAuthDataRepository
 import us.docbee.docbeeapp.data.repositories.JsonCountryRepository
+import us.docbee.docbeeapp.data.repositories.UserDataRepository
 import us.docbee.docbeeapp.domain.repositories.CountryRepository
 import us.docbee.docbeeapp.domain.repositories.EmailAuthRepository
+import us.docbee.docbeeapp.domain.repositories.UserRepository
 import us.docbee.docbeeapp.domain.usecases.EmailAuthUseCase
 import us.docbee.docbeeapp.domain.usecases.EmailSignupUseCase
 import us.docbee.docbeeapp.domain.usecases.GetCountriesUseCase
@@ -20,16 +24,18 @@ import us.docbee.docbeeapp.presentation.login.SignupViewModel
 val dataSourcesModule = module {
     factory<EmailAuth> { getEmailAuth() }
     factory<ResourcesLoader> { JsonResourceLoader() }
+    factory<UserRemoteDataSource> { getUserDataSource() }
 }
 
 val repositoryModule = module {
     factory<EmailAuthRepository> { EmailAuthDataRepository(get()) }
     factory<CountryRepository> { JsonCountryRepository(get()) }
+    factory<UserRepository> { UserDataRepository(get()) }
 }
 
 val usesCasesModule = module {
     factory { EmailAuthUseCase(get()) }
-    factory { EmailSignupUseCase(get()) }
+    factory { EmailSignupUseCase(get(), get()) }
     factory { GetCountriesUseCase(get()) }
 }
 

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/mappers/UserProfileMapper.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/mappers/UserProfileMapper.kt
@@ -1,0 +1,24 @@
+package us.docbee.docbeeapp.domain.mappers
+
+import us.docbee.docbeeapp.domain.models.signup.SignUpParams
+import us.docbee.docbeeapp.domain.models.user.UserProfile
+
+fun UserProfile.toMap(): Map<Any?, *> = mapOf(
+    "uid" to uid,
+    "name" to name,
+    "lastname" to lastname,
+    "email" to email,
+    "dateOfBirth" to dateOfBirth,
+    "phone" to phoneNumber,
+    "createdAt" to createdAt
+)
+
+fun SignUpParams.toUserProfile(uid: String, createdAd: Long): UserProfile = UserProfile(
+    uid = uid,
+    name = name,
+    lastname = lastName,
+    email = email,
+    dateOfBirth = dateOfBirth,
+    phoneNumber = phoneNumber,
+    createdAt = createdAd
+)

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/user/UserProfile.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/user/UserProfile.kt
@@ -1,0 +1,11 @@
+package us.docbee.docbeeapp.domain.models.user
+
+data class UserProfile(
+    val uid: String,
+    val name: String,
+    val lastname: String,
+    val dateOfBirth: String,
+    val phoneNumber: String,
+    val email: String,
+    val createdAt: Long
+)

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/repositories/UserRepository.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/repositories/UserRepository.kt
@@ -1,0 +1,7 @@
+package us.docbee.docbeeapp.domain.repositories
+
+import us.docbee.docbeeapp.domain.models.user.UserProfile
+
+interface UserRepository {
+    suspend fun saveUserProfile(profile: UserProfile)
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/usecases/EmailSignupUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/usecases/EmailSignupUseCase.kt
@@ -1,5 +1,7 @@
 package us.docbee.docbeeapp.domain.usecases
 
+import kotlinx.datetime.Clock
+import us.docbee.docbeeapp.domain.mappers.toUserProfile
 import us.docbee.docbeeapp.domain.models.DateOfBirthValidation
 import us.docbee.docbeeapp.domain.models.EmailTextValidation
 import us.docbee.docbeeapp.domain.models.PasswordValidation
@@ -7,6 +9,7 @@ import us.docbee.docbeeapp.domain.models.SimpleTextValidation
 import us.docbee.docbeeapp.domain.models.UserSignupResult
 import us.docbee.docbeeapp.domain.models.signup.SignUpParams
 import us.docbee.docbeeapp.domain.repositories.EmailAuthRepository
+import us.docbee.docbeeapp.domain.repositories.UserRepository
 import us.docbee.docbeeapp.utils.PASSWORD_MINIMUM_LENGTH
 import us.docbee.docbeeapp.utils.PHONE_MAXIMUM_LENGTH
 import us.docbee.docbeeapp.utils.PHONE_MINIMUM_LENGTH
@@ -14,7 +17,8 @@ import us.docbee.docbeeapp.utils.hasSpecialChars
 import us.docbee.docbeeapp.utils.isValidEmail
 
 class EmailSignupUseCase(
-    private val emailAuthRepository: EmailAuthRepository
+    private val emailAuthRepository: EmailAuthRepository,
+    private val userDataRepository: UserRepository
 ) {
     suspend fun createUser(userInformation: SignUpParams): UserSignupResult {
         val nameValidation = validateNames(userInformation.name)
@@ -38,7 +42,19 @@ class EmailSignupUseCase(
             )
         }
 
-        return emailAuthRepository.signup(userInformation.email, userInformation.password)
+        val signupResult =
+            emailAuthRepository.signup(userInformation.email, userInformation.password)
+
+        if (signupResult is UserSignupResult.Success) {
+            userDataRepository.saveUserProfile(
+                userInformation.toUserProfile(
+                    uid = signupResult.uid,
+                    createdAd = Clock.System.now().toEpochMilliseconds()
+                )
+            )
+        }
+
+        return signupResult
     }
 
     private fun validateNames(name: String): SimpleTextValidation {

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/utils/Contants.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/utils/Contants.kt
@@ -7,3 +7,4 @@ const val COUNTRY_DEFAULT_ICON: String = "files/flags/us.png"
 const val PHONE_MINIMUM_LENGTH = 8
 const val PHONE_MAXIMUM_LENGTH = 13
 const val PASSWORD_MINIMUM_LENGTH = 8
+const val FIRESTORE_COLLECTION_USER = "users"

--- a/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/data/datasources/UserRemoteDataSource.ios.kt
+++ b/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/data/datasources/UserRemoteDataSource.ios.kt
@@ -1,0 +1,28 @@
+package us.docbee.docbeeapp.data.datasources
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import us.docbee.docbeeapp.domain.mappers.toMap
+import us.docbee.docbeeapp.domain.models.user.UserProfile
+import us.docbee.docbeeapp.utils.FIRESTORE_COLLECTION_USER
+import us.docbee.docbeeapp.wrappers.UserRemoteStorage
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalCoroutinesApi::class)
+class IosUserRemoteDataSource : UserRemoteDataSource {
+
+    private val remote = UserRemoteStorage()
+
+    override suspend fun saveUser(profile: UserProfile) {
+        suspendCancellableCoroutine<Unit> { thread ->
+            remote.saveUserWithCollection(
+                collection = FIRESTORE_COLLECTION_USER,
+                profile = profile.toMap()
+            ) { error ->
+                thread.resume(Unit, null)
+            }
+        }
+    }
+}
+
+actual fun getUserDataSource(): UserRemoteDataSource = IosUserRemoteDataSource()

--- a/composeApp/src/nativeInterop/cinterop/UserRemoteStorage.h
+++ b/composeApp/src/nativeInterop/cinterop/UserRemoteStorage.h
@@ -1,0 +1,21 @@
+//
+//  UserRemoteStorage.h
+//  iosApp
+//
+//  Created by Jorge Torres on 31/07/25.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UserRemoteStorage : NSObject
+
+- (void)saveUserWithCollection:(NSString *)collection
+                       profile:(NSDictionary *)profile
+                    completion:(void (^)(NSError * _Nullable error))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:life
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref="firebase" }
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
+firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore" }
 koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koin"}
 koin-core = { group = "io.insert-koin", name = "koin-core" }
 koin-compose = { group = "io.insert-koin", name = "koin-compose" }

--- a/iosApp/iosApp/Wrappers/Interops/UserRemoteStorage.h
+++ b/iosApp/iosApp/Wrappers/Interops/UserRemoteStorage.h
@@ -1,0 +1,20 @@
+//
+//  UserRemoteStorage.h
+//  iosApp
+//
+//  Created by Jorge Torres on 03/08/25.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UserRemoteStorage : NSObject
+
+- (void)saveUserWithCollection:(NSString *)collection
+                       profile:(NSDictionary *)profile
+                    completion:(void (^)(NSError * _Nullable error))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iosApp/iosApp/Wrappers/Interops/Wrappers.def
+++ b/iosApp/iosApp/Wrappers/Interops/Wrappers.def
@@ -1,3 +1,3 @@
 language = Objective-C
-headers = UserRemoteAuthentication.h
+headers = UserRemoteAuthentication.h UserRemoteStorage.h
 package = us.docbee.docbeeapp.wrappers

--- a/iosApp/iosApp/Wrappers/UserRemoteStorage.swift
+++ b/iosApp/iosApp/Wrappers/UserRemoteStorage.swift
@@ -1,0 +1,30 @@
+//
+//  UserRemoteStorage.swift
+//  iosApp
+//
+//  Created by Jorge Torres on 30/07/25.
+//
+
+import Foundation
+import FirebaseFirestore
+
+@objc(UserRemoteStorage)
+public class UserRemoteStorage: NSObject {
+    
+    @objc public func saveUser(collection: String, profile: NSDictionary, completion: @escaping (NSError?) -> Void) {
+        let db = Firestore.firestore()
+        
+        var data: [String: Any] = [:]
+        for (key, value) in profile {
+            if let keyString = key as? String {
+                data[keyString] = value
+            }
+        }
+        
+        db.collection(collection)
+            .document(data["uid"] as? String ?? "")
+            .setData(data) { error in
+                completion(error as NSError?)
+            }
+    }
+}


### PR DESCRIPTION
# Add Firestore Integration to Save Users After Signup

## Description

This PR adds **Firestore integration** to the signup flow. After a user account is successfully created using Firebase Authentication, their additional data is now stored in **Cloud Firestore**.

### Key Features

- ✅ Firestore write operation triggered after successful user signup
- ✅ Firestore logic implemented in shared Kotlin Multiplatform code where possible
- ✅ Error handling included for write failures

### Example saved user
<img width="1155" height="412" alt="image" src="https://github.com/user-attachments/assets/c5273be8-f0a3-4f4d-8769-5e1bd9ac74e9" />



