### PR TITLE
feat: Add Dashboard Screen and Bottom Navigation

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
             implementation(compose.ui)
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
+            implementation(compose.materialIconsExtended)
             implementation(libs.androidx.lifecycle.viewmodel)
             implementation(libs.androidx.lifecycle.runtimeCompose)
             implementation(project.dependencies.platform(libs.koin.bom))

--- a/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/MainActivity.kt
@@ -17,9 +17,3 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
-
-@Preview
-@Composable
-fun AppAndroidPreview() {
-    App()
-}

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -44,6 +44,23 @@
     <string name="modal_country_code_search_not_found">No results found</string>
     <string name="modal_country_code_search_not_found_description">Try searching with different keywords or check your spelling to find what you’re looking for.</string>
 
+    <string name="dashboard_home_title">Home</string>
+    <string name="dashboard_directory_title">Directory</string>
+    <string name="dashboard_history_title">History</string>
+    <string name="dashboard_settings_title">Settings</string>
+
+    <string name="home_emergency_app_bar_title">Emergency</string>
+    <string name="home_emergency_app_bar_subtitle">Please inform your family members about your emergency</string>
+
+    <string name="home_directory_app_bar_title">Directory</string>
+    <string name="home_directory_app_bar_subtitle">Please check and review your emergency contacts</string>
+
+    <string name="home_history_app_bar_title">History</string>
+    <string name="home_history_app_bar_subtitle">History check</string>
+
+    <string name="home_settings_app_bar_title">Settings</string>
+    <string name="home_settings_app_bar_subtitle">Modify your perfil and settings</string>
+
     <string name="general_label_or">Or</string>
     <string name="general_label_ok">Ok</string>
     <string name="general_label_cancel">Cancel</string>

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/menus/BottomMenuBar.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/menus/BottomMenuBar.kt
@@ -1,0 +1,75 @@
+package us.docbee.docbeeapp.presentation.components.menus
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.jetbrains.compose.resources.stringResource
+import us.docbee.docbeeapp.presentation.dashboard.navigation.MenuBarItem
+import us.docbee.docbeeapp.presentation.theme.White
+
+@Composable
+fun BottomMenuBar(
+    selectedItem: MenuBarItem = MenuBarItem.HOME,
+    onItemClick: (MenuBarItem) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        MenuBarItem.entries.forEach { item ->
+            MenuBarButton(
+                modifier = Modifier.weight(1f),
+                item = item,
+                isSelected = item == selectedItem,
+                onClick = { onItemClick(item) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun MenuBarButton(
+    item: MenuBarItem,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .clickable { onClick() }
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = if (isSelected) item.icon else item.iconLinear,
+            contentDescription = stringResource(item.label),
+            tint = White,
+            modifier = Modifier.size(24.dp)
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = stringResource(item.label),
+            color = White,
+            fontSize = if (isSelected) 14.sp else 12.sp,
+            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/menus/BottomMenuBar.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/menus/BottomMenuBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.jetbrains.compose.resources.stringResource
@@ -69,7 +70,9 @@ private fun MenuBarButton(
             text = stringResource(item.label),
             color = White,
             fontSize = if (isSelected) 14.sp else 12.sp,
-            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal
+            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 1
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/toolbar/Toolbar.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/toolbar/Toolbar.kt
@@ -1,0 +1,67 @@
+package us.docbee.docbeeapp.presentation.components.toolbar
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+import us.docbee.docbeeapp.presentation.theme.White
+
+@Composable
+fun Toolbar(
+    title: StringResource,
+    subtitle: StringResource,
+    onBackClicked: () -> Unit
+) {
+    Box(
+        modifier = Modifier.windowInsetsPadding(WindowInsets.statusBars)
+            .padding(top = 32.dp, bottom = 24.dp)
+            .fillMaxWidth()
+    ) {
+        Icon(
+            modifier = Modifier
+                .padding(start = 42.dp)
+                .size(24.dp)
+                .clickable { onBackClicked() },
+            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = null,
+            tint = White
+        )
+        Column(
+            modifier = Modifier.align(Alignment.Center).padding(horizontal = 64.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = stringResource(title),
+                style = MaterialTheme.typography.headlineMedium,
+                textAlign = TextAlign.Center,
+                color = White
+            )
+            Spacer(modifier = Modifier.height(20.dp))
+            Text(
+                text = stringResource(subtitle),
+                style = MaterialTheme.typography.labelLarge,
+                textAlign = TextAlign.Center,
+                color = White
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/toolbar/ToolbarContent.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/toolbar/ToolbarContent.kt
@@ -1,0 +1,39 @@
+package us.docbee.docbeeapp.presentation.components.toolbar
+
+import docbee.composeapp.generated.resources.Res
+import docbee.composeapp.generated.resources.home_directory_app_bar_subtitle
+import docbee.composeapp.generated.resources.home_directory_app_bar_title
+import docbee.composeapp.generated.resources.home_emergency_app_bar_subtitle
+import docbee.composeapp.generated.resources.home_emergency_app_bar_title
+import docbee.composeapp.generated.resources.home_history_app_bar_subtitle
+import docbee.composeapp.generated.resources.home_history_app_bar_title
+import docbee.composeapp.generated.resources.home_settings_app_bar_subtitle
+import docbee.composeapp.generated.resources.home_settings_app_bar_title
+import org.jetbrains.compose.resources.StringResource
+import us.docbee.docbeeapp.presentation.dashboard.navigation.MenuBarItem
+
+data class ToolbarContent(
+    val title: StringResource,
+    val description: StringResource
+)
+
+fun fetchToolbarContent(item: MenuBarItem): ToolbarContent {
+    return when (item) {
+        MenuBarItem.HOME -> ToolbarContent(
+            title = Res.string.home_emergency_app_bar_title,
+            description = Res.string.home_emergency_app_bar_subtitle
+        )
+        MenuBarItem.DIRECTORY -> ToolbarContent(
+            title = Res.string.home_directory_app_bar_title,
+            description = Res.string.home_directory_app_bar_subtitle
+        )
+        MenuBarItem.HISTORY -> ToolbarContent(
+            title = Res.string.home_history_app_bar_title,
+            description = Res.string.home_history_app_bar_subtitle
+        )
+        MenuBarItem.SETTINGS -> ToolbarContent(
+            title = Res.string.home_settings_app_bar_title,
+            description = Res.string.home_settings_app_bar_subtitle
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/DashboardScreen.kt
@@ -1,0 +1,59 @@
+package us.docbee.docbeeapp.presentation.dashboard
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import us.docbee.docbeeapp.presentation.components.menus.BottomMenuBar
+import us.docbee.docbeeapp.presentation.components.toolbar.Toolbar
+import us.docbee.docbeeapp.presentation.components.toolbar.fetchToolbarContent
+import us.docbee.docbeeapp.presentation.dashboard.navigation.DashboardNavigation
+import us.docbee.docbeeapp.presentation.dashboard.navigation.MenuBarItem
+import us.docbee.docbeeapp.presentation.theme.Black
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DashboardScreen(parentNavController: NavHostController) {
+    val dashboardNavController = rememberNavController()
+    var selectedItem by remember { mutableStateOf(MenuBarItem.HOME) }
+    val contentToolbar = remember(selectedItem) { fetchToolbarContent(selectedItem) }
+    Scaffold(
+        modifier = Modifier
+            .windowInsetsPadding(WindowInsets.navigationBars),
+        containerColor = Black,
+        topBar = {
+            Toolbar(
+                title = contentToolbar.title,
+                subtitle = contentToolbar.description,
+                onBackClicked = { }
+            )
+        },
+        bottomBar = {
+            BottomMenuBar(
+                selectedItem = selectedItem,
+                onItemClick = { item ->
+                    selectedItem = item
+                    dashboardNavController.navigate(item.route)
+                },
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            )
+        }
+    ) { parentPadding ->
+        DashboardNavigation(
+            modifier = Modifier.padding(parentPadding),
+            navController = dashboardNavController,
+            parentNavController = dashboardNavController
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/DashboardNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/DashboardNavigation.kt
@@ -1,0 +1,28 @@
+package us.docbee.docbeeapp.presentation.dashboard.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import us.docbee.docbeeapp.presentation.dashboard.navigation.routes.addDirectoryNav
+import us.docbee.docbeeapp.presentation.dashboard.navigation.routes.addHistoryNav
+import us.docbee.docbeeapp.presentation.dashboard.navigation.routes.addHomeNav
+import us.docbee.docbeeapp.presentation.dashboard.navigation.routes.addSettingsNav
+
+@Composable
+fun DashboardNavigation(
+    navController: NavHostController,
+    parentNavController: NavHostController,
+    modifier: Modifier = Modifier
+) {
+    NavHost(
+        navController = navController,
+        startDestination = DashboardRoutes.HomeRoute,
+        modifier = modifier
+    ) {
+        addHomeNav(navController)
+        addDirectoryNav(navController)
+        addSettingsNav(navController)
+        addHistoryNav(navController)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/DashboardNavigationRoutes.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/DashboardNavigationRoutes.kt
@@ -1,0 +1,18 @@
+package us.docbee.docbeeapp.presentation.dashboard.navigation
+
+import kotlinx.serialization.Serializable
+
+
+sealed class DashboardRoutes {
+    @Serializable
+    data object HomeRoute: DashboardRoutes()
+
+    @Serializable
+    data object DirectoryRoute: DashboardRoutes()
+
+    @Serializable
+    data object HistoryRoute: DashboardRoutes()
+
+    @Serializable
+    data object SettingsRoute: DashboardRoutes()
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/MenuBarItem.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/MenuBarItem.kt
@@ -1,0 +1,50 @@
+package us.docbee.docbeeapp.presentation.dashboard.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.automirrored.outlined.List
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.ui.graphics.vector.ImageVector
+import docbee.composeapp.generated.resources.Res
+import docbee.composeapp.generated.resources.dashboard_directory_title
+import docbee.composeapp.generated.resources.dashboard_history_title
+import docbee.composeapp.generated.resources.dashboard_home_title
+import docbee.composeapp.generated.resources.dashboard_settings_title
+import org.jetbrains.compose.resources.StringResource
+
+enum class MenuBarItem(
+    val icon: ImageVector,
+    val iconLinear: ImageVector,
+    val label: StringResource,
+    val route: DashboardRoutes
+) {
+    HOME(
+        Icons.Default.Home,
+        Icons.Outlined.Home,
+        Res.string.dashboard_home_title,
+        DashboardRoutes.HomeRoute
+    ),
+    DIRECTORY(
+        Icons.AutoMirrored.Filled.List,
+        Icons.AutoMirrored.Outlined.List,
+        Res.string.dashboard_directory_title,
+        DashboardRoutes.DirectoryRoute
+    ),
+    HISTORY(
+        Icons.Default.Info,
+        Icons.Outlined.Info,
+        Res.string.dashboard_history_title,
+        DashboardRoutes.HistoryRoute
+    ),
+    SETTINGS(
+        Icons.Default.Settings,
+        Icons.Outlined.Settings,
+        Res.string.dashboard_settings_title,
+        DashboardRoutes.SettingsRoute
+    )
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/DirectoryNav.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/DirectoryNav.kt
@@ -1,0 +1,13 @@
+package us.docbee.docbeeapp.presentation.dashboard.navigation.routes
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import us.docbee.docbeeapp.presentation.dashboard.navigation.DashboardRoutes
+import us.docbee.docbeeapp.presentation.directory.DirectoryScreen
+
+fun NavGraphBuilder.addDirectoryNav(navHostController: NavHostController) {
+    composable<DashboardRoutes.DirectoryRoute> {
+        DirectoryScreen(navController = navHostController)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/HistoryNav.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/HistoryNav.kt
@@ -1,0 +1,13 @@
+package us.docbee.docbeeapp.presentation.dashboard.navigation.routes
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import us.docbee.docbeeapp.presentation.dashboard.navigation.DashboardRoutes
+import us.docbee.docbeeapp.presentation.history.HistoryScreen
+
+fun NavGraphBuilder.addHistoryNav(navHostController: NavHostController) {
+    composable<DashboardRoutes.HistoryRoute> {
+        HistoryScreen(navController = navHostController)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/HomeNav.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/HomeNav.kt
@@ -1,0 +1,13 @@
+package us.docbee.docbeeapp.presentation.dashboard.navigation.routes
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import us.docbee.docbeeapp.presentation.dashboard.navigation.DashboardRoutes
+import us.docbee.docbeeapp.presentation.home.HomeScreen
+
+fun NavGraphBuilder.addHomeNav(navHostController: NavHostController) {
+    composable<DashboardRoutes.HomeRoute> {
+        HomeScreen(navController = navHostController)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/SettingsNav.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/SettingsNav.kt
@@ -1,0 +1,13 @@
+package us.docbee.docbeeapp.presentation.dashboard.navigation.routes
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import us.docbee.docbeeapp.presentation.dashboard.navigation.DashboardRoutes
+import us.docbee.docbeeapp.presentation.settings.SettingsScreen
+
+fun NavGraphBuilder.addSettingsNav(navHostController: NavHostController) {
+    composable<DashboardRoutes.SettingsRoute> {
+        SettingsScreen(navController = navHostController)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/DirectoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/DirectoryScreen.kt
@@ -1,0 +1,79 @@
+package us.docbee.docbeeapp.presentation.directory
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+
+@Composable
+fun DirectoryScreen(navController: NavHostController) {
+    val sampleFolders = listOf(
+        "Documents",
+        "Images",
+        "Projects",
+        "Archive",
+        "Templates",
+        "Shared"
+    )
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        item {
+            Text(
+                text = "Directory",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+        }
+
+        items(sampleFolders) { folder ->
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.List,
+                        contentDescription = "Folder",
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = folder,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/history/HistoryScreen.kt
@@ -1,0 +1,78 @@
+package us.docbee.docbeeapp.presentation.history
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+
+@Composable
+fun HistoryScreen(navController: NavHostController) {
+    val sampleAlerts = listOf(
+        "New document shared with you",
+        "Backup completed successfully",
+        "Storage is 80% full",
+        "Document 'Project Plan' was updated",
+        "New version available"
+    )
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        item {
+            Text(
+                text = "Alerts",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+        }
+
+        items(sampleAlerts) { alert ->
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Notifications,
+                        contentDescription = "Alert",
+                        tint = MaterialTheme.colorScheme.onErrorContainer,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = alert,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/HomeScreen.kt
@@ -1,0 +1,65 @@
+package us.docbee.docbeeapp.presentation.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import docbee.composeapp.generated.resources.Res
+import docbee.composeapp.generated.resources.dashboard_home_title
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun HomeScreen(navController: NavHostController) {
+    Card(
+        modifier = Modifier.fillMaxSize(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Home,
+                contentDescription = stringResource(Res.string.dashboard_home_title),
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            // TODO -> Remove hardcoded texts
+            Text(
+                text = "Welcome to DocBee",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "This is the home screen where you can see an overview of your documents and recent activity.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/AuthScreen.kt
@@ -49,6 +49,7 @@ import docbee.composeapp.generated.resources.login_title_label
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
 import us.docbee.docbeeapp.presentation.components.PrimaryButton
+import us.docbee.docbeeapp.presentation.navigation.DashboardRoute
 import us.docbee.docbeeapp.presentation.theme.Black
 import us.docbee.docbeeapp.presentation.theme.Black100
 import us.docbee.docbeeapp.presentation.theme.Blue100
@@ -66,7 +67,8 @@ fun AuthScreen(navController: NavController) {
         AuthScreenContent(
             isLoginTab = isLoginTabSelected,
             onTabClicked = { isLoginTab -> isLoginTabSelected = isLoginTab },
-            snackbarState = snackbarHostState
+            snackbarState = snackbarHostState,
+            onAuthenticationSuccess = { navController.navigate(DashboardRoute) }
         )
         SnackbarHost(
             hostState = snackbarHostState,
@@ -81,7 +83,8 @@ fun AuthScreen(navController: NavController) {
 fun AuthScreenContent(
     isLoginTab: Boolean,
     onTabClicked: (isLoginSelected: Boolean) -> Unit,
-    snackbarState: SnackbarHostState
+    snackbarState: SnackbarHostState,
+    onAuthenticationSuccess: () -> Unit
 ) {
     Column(
         modifier = Modifier.fillMaxSize()
@@ -127,12 +130,14 @@ fun AuthScreenContent(
             LoginScreen(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 42.dp),
                 snackbarState = snackbarState,
-                isLoginTabbed = isLoginTab
+                isLoginTabbed = isLoginTab,
+                onAuthenticationSuccess = onAuthenticationSuccess
             )
             SignupScreen(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 42.dp),
                 snackbarState = snackbarState,
-                isSignupTabbed = !isLoginTab
+                isSignupTabbed = !isLoginTab,
+                onAuthenticationSuccess = onAuthenticationSuccess
             )
             LoginSocialButtons(modifier = Modifier.fillMaxWidth().padding(horizontal = 42.dp))
         }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/LoginScreen.kt
@@ -45,6 +45,7 @@ fun LoginScreen(
     modifier: Modifier = Modifier,
     snackbarState: SnackbarHostState,
     isLoginTabbed: Boolean,
+    onAuthenticationSuccess: () -> Unit,
     viewModel: LoginViewModel = koinViewModel()
 ) {
     val state by viewModel.state.collectAsState()
@@ -64,7 +65,7 @@ fun LoginScreen(
                 }
 
                 is LoginEffect.NavigateToForgotPassword -> Unit
-                is LoginEffect.NavigateToDashboard -> Unit
+                is LoginEffect.NavigateToDashboard -> onAuthenticationSuccess()
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/SignupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/SignupScreen.kt
@@ -48,6 +48,7 @@ fun SignupScreen(
     modifier: Modifier = Modifier,
     snackbarState: SnackbarHostState,
     isSignupTabbed: Boolean,
+    onAuthenticationSuccess: () -> Unit,
     viewModel: SignupViewModel = koinViewModel()
 ) {
     val state = viewModel.uiState.collectAsState()
@@ -70,7 +71,7 @@ fun SignupScreen(
 
                 is SignupEffect.OpenCountrySelector -> isCountrySelectorVisible = true
                 is SignupEffect.CloseCountrySelector -> isCountrySelectorVisible = false
-                is SignupEffect.NavigateToDashboard -> Unit
+                is SignupEffect.NavigateToDashboard -> onAuthenticationSuccess()
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/AppNavigator.kt
@@ -2,8 +2,8 @@ package us.docbee.docbeeapp.presentation.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
-
 import androidx.navigation.compose.rememberNavController
+import us.docbee.docbeeapp.presentation.navigation.routes.addDashboardNav
 import us.docbee.docbeeapp.presentation.navigation.routes.addLoginNav
 
 @Composable
@@ -14,5 +14,6 @@ fun AppNavigator() {
         startDestination = AuthenticationRoute
     ) {
         addLoginNav(navController)
+        addDashboardNav(navController)
     }
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/NavigationRoutes.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/NavigationRoutes.kt
@@ -4,3 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data object AuthenticationRoute
+
+@Serializable
+data object DashboardRoute

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/routes/DashboardRoute.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/routes/DashboardRoute.kt
@@ -1,0 +1,13 @@
+package us.docbee.docbeeapp.presentation.navigation.routes
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import us.docbee.docbeeapp.presentation.dashboard.DashboardScreen
+import us.docbee.docbeeapp.presentation.navigation.DashboardRoute
+
+fun NavGraphBuilder.addDashboardNav(navController: NavHostController) {
+    composable<DashboardRoute> {
+        DashboardScreen(navController)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/settings/SettingsScreen.kt
@@ -1,0 +1,90 @@
+package us.docbee.docbeeapp.presentation.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import docbee.composeapp.generated.resources.Res
+import docbee.composeapp.generated.resources.dashboard_settings_title
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun SettingsScreen(navController: NavHostController) {
+    val settingsItems = listOf(
+        "Account Settings",
+        "Privacy & Security",
+        "Notifications",
+        "Storage Management",
+        "Backup & Sync",
+        "About"
+    )
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        item {
+            Text(
+                text = stringResource(Res.string.dashboard_settings_title),
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+        }
+
+        items(settingsItems) { setting ->
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Settings,
+                        contentDescription = stringResource(Res.string.dashboard_settings_title),
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = setting,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    Icon(
+                        imageVector = Icons.Default.ChevronRight,
+                        contentDescription = "Navigate",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Add Dashboard Screen and Bottom Navigation

## Description

This PR introduces the **Dashboard** as a main entry point after authentication, along with a **Bottom Navigation** system to organize core sections of the app.

## Visual Evidence

Android

https://github.com/user-attachments/assets/456c24b2-1e6d-4004-8ccd-64aa76916c04


iOS

https://github.com/user-attachments/assets/49ee3e9a-187c-4200-a42f-24a6ce93bb6a


