### PR TITLE
feat: Create form for registering a new contact

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -63,6 +63,16 @@
     <string name="home_settings_app_bar_title">Settings</string>
     <string name="home_settings_app_bar_subtitle">Modify your perfil and settings</string>
 
+    <string name="add_contact_app_bar_title">New Contact</string>
+    <string name="add_contact_app_bar_subtitle">Let’s create a new user</string>
+    <string name="add_contact_form_name_field">First Name</string>
+    <string name="add_contact_form_lastname_field">Last Name</string>
+    <string name="add_contact_form_email_field">Email</string>
+    <string name="add_contact_form_birth_date_field">Birth of date</string>
+    <string name="add_contact_form_phone_field">Phone Number</string>
+    <string name="add_contact_form_address_field">Address</string>
+    <string name="add_contact_form_register_label">Save</string>
+
     <string name="general_label_or">Or</string>
     <string name="general_label_ok">Ok</string>
     <string name="general_label_cancel">Cancel</string>

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
@@ -23,7 +23,9 @@ import us.docbee.docbeeapp.domain.usecases.EmailAuthUseCase
 import us.docbee.docbeeapp.domain.usecases.EmailSignupUseCase
 import us.docbee.docbeeapp.domain.usecases.GetCountriesUseCase
 import us.docbee.docbeeapp.domain.usecases.GetUserContactsUseCase
+import us.docbee.docbeeapp.domain.usecases.SaveUserContactUseCase
 import us.docbee.docbeeapp.presentation.dashboard.DashboardViewModel
+import us.docbee.docbeeapp.presentation.directory.AddContactViewModel
 import us.docbee.docbeeapp.presentation.directory.DirectoryViewModel
 import us.docbee.docbeeapp.presentation.login.LoginViewModel
 import us.docbee.docbeeapp.presentation.login.SignupViewModel
@@ -47,6 +49,7 @@ val usesCasesModule = module {
     factory { EmailSignupUseCase(get(), get()) }
     factory { GetCountriesUseCase(get()) }
     factory { GetUserContactsUseCase(get(), get()) }
+    factory { SaveUserContactUseCase(get(), get()) }
 }
 
 val viewModelsModule = module {
@@ -54,6 +57,7 @@ val viewModelsModule = module {
     viewModelOf(::SignupViewModel)
     viewModelOf(::DashboardViewModel)
     viewModelOf(::DirectoryViewModel)
+    viewModelOf(::AddContactViewModel)
 }
 
 fun initKoin() {

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/mappers/ContactsMapper.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/mappers/ContactsMapper.kt
@@ -1,6 +1,7 @@
 package us.docbee.docbeeapp.domain.mappers
 
 import us.docbee.docbeeapp.domain.models.directory.ContactModel
+import us.docbee.docbeeapp.domain.models.signup.ContactParams
 
 fun ContactModel.toMap(): Map<Any?, *> = mapOf(
     "firstName" to firstName,
@@ -27,4 +28,13 @@ fun MutableMap<String, Any>.toContactDomain() = ContactModel(
     phoneNumber = this["phoneNumber"] as String,
     gender = this["gender"] as String,
     address = this["address"] as String
+)
+
+fun ContactParams.toContactModel(): ContactModel = ContactModel(
+    firstName = name,
+    lastName = lastName,
+    email = email,
+    dateOfBirth = dateOfBirth,
+    phoneNumber = phoneNumber,
+    address = address,
 )

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/directory/AddContactResult.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/directory/AddContactResult.kt
@@ -1,0 +1,7 @@
+package us.docbee.docbeeapp.domain.models.directory
+
+sealed class AddContactResult {
+    data object Success: AddContactResult()
+    data object Error: AddContactResult()
+    data object Unauthorized: AddContactResult()
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/directory/ContactModel.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/directory/ContactModel.kt
@@ -6,6 +6,7 @@ data class ContactModel(
     val lastName: String = "",
     val email: String = "",
     val phoneNumber: String = "",
+    val dateOfBirth: String = "",
     val address: String = "",
     val gender: String = ""
 )

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/signup/ContactParams.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/signup/ContactParams.kt
@@ -1,0 +1,10 @@
+package us.docbee.docbeeapp.domain.models.signup
+
+data class ContactParams(
+    val name: String,
+    val lastName: String,
+    val email: String,
+    val dateOfBirth: String,
+    val phoneNumber: String,
+    val address: String
+)

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/usecases/SaveUserContactUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/usecases/SaveUserContactUseCase.kt
@@ -1,0 +1,23 @@
+package us.docbee.docbeeapp.domain.usecases
+
+import us.docbee.docbeeapp.domain.mappers.toContactModel
+import us.docbee.docbeeapp.domain.models.directory.AddContactResult
+import us.docbee.docbeeapp.domain.models.directory.UserUidResult
+import us.docbee.docbeeapp.domain.models.signup.ContactParams
+import us.docbee.docbeeapp.domain.repositories.ContactsRepository
+import us.docbee.docbeeapp.domain.repositories.UserRepository
+
+class SaveUserContactUseCase(
+    val repository: ContactsRepository,
+    val userRepository: UserRepository
+) {
+    suspend fun saveUserContact(contact: ContactParams): AddContactResult {
+        val userId = userRepository.fetchUserId()
+
+        if (userId !is UserUidResult.Success) {
+            return AddContactResult.Unauthorized
+        }
+        repository.saveUserContact(userId.uid, contact.toContactModel())
+        return AddContactResult.Success
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/inputs/InputDateFieldText.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/inputs/InputDateFieldText.kt
@@ -44,6 +44,7 @@ import us.docbee.docbeeapp.presentation.theme.Blue100
 import us.docbee.docbeeapp.presentation.theme.Gray
 import us.docbee.docbeeapp.presentation.theme.Gray300
 import us.docbee.docbeeapp.presentation.theme.Gray400
+import us.docbee.docbeeapp.presentation.theme.White
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -100,7 +101,9 @@ fun InputDateFieldText(
                     unfocusedBorderColor = Gray300,
                     focusedBorderColor = Blue100,
                     focusedTextColor = Black100,
-                    unfocusedTextColor = Black100
+                    unfocusedTextColor = Black100,
+                    focusedContainerColor = White,
+                    unfocusedContainerColor = White
                 ),
                 textStyle = MaterialTheme.typography.bodyMedium,
                 shape = RoundedCornerShape(10.dp),

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/inputs/InputFieldText.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/inputs/InputFieldText.kt
@@ -29,6 +29,7 @@ import us.docbee.docbeeapp.presentation.theme.Blue100
 import us.docbee.docbeeapp.presentation.theme.Gray
 import us.docbee.docbeeapp.presentation.theme.Gray300
 import us.docbee.docbeeapp.presentation.theme.Gray400
+import us.docbee.docbeeapp.presentation.theme.White
 
 @Composable
 fun InputFieldText(
@@ -68,7 +69,9 @@ fun InputFieldText(
                 unfocusedBorderColor = Gray300,
                 focusedBorderColor = Blue100,
                 focusedTextColor = Black100,
-                unfocusedTextColor = Black100
+                unfocusedTextColor = Black100,
+                focusedContainerColor = White,
+                unfocusedContainerColor = White
             ),
             keyboardOptions = KeyboardOptions(
                 capitalization = keyboardCapitalization,

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/inputs/countrycodefield/InputCountryCodeFieldText.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/inputs/countrycodefield/InputCountryCodeFieldText.kt
@@ -48,6 +48,7 @@ import us.docbee.docbeeapp.presentation.theme.Black100
 import us.docbee.docbeeapp.presentation.theme.Blue100
 import us.docbee.docbeeapp.presentation.theme.Gray
 import us.docbee.docbeeapp.presentation.theme.Gray300
+import us.docbee.docbeeapp.presentation.theme.White
 import us.docbee.docbeeapp.utils.COUNTRY_DEFAULT_ICON
 
 @Composable
@@ -93,7 +94,9 @@ fun InputCountryCodeFieldText(
                 unfocusedBorderColor = Gray300,
                 focusedBorderColor = Blue100,
                 focusedTextColor = Black100,
-                unfocusedTextColor = Black100
+                unfocusedTextColor = Black100,
+                focusedContainerColor = White,
+                unfocusedContainerColor = White
             ),
             textStyle = MaterialTheme.typography.bodyMedium,
             shape = RoundedCornerShape(10.dp),

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/DashboardScreen.kt
@@ -97,7 +97,7 @@ fun DashboardScreen(
         DashboardNavigation(
             modifier = Modifier.padding(parentPadding),
             navController = dashboardNavController,
-            parentNavController = dashboardNavController
+            parentNavController = parentNavController
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/DashboardNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/DashboardNavigation.kt
@@ -21,7 +21,7 @@ fun DashboardNavigation(
         modifier = modifier
     ) {
         addHomeNav(navController)
-        addDirectoryNav(navController)
+        addDirectoryNav(parentNavController = parentNavController, navController = navController)
         addSettingsNav(navController)
         addHistoryNav(navController)
     }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/DirectoryNav.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/DirectoryNav.kt
@@ -7,8 +7,15 @@ import org.koin.compose.viewmodel.koinViewModel
 import us.docbee.docbeeapp.presentation.dashboard.navigation.DashboardRoutes
 import us.docbee.docbeeapp.presentation.directory.DirectoryScreen
 
-fun NavGraphBuilder.addDirectoryNav(navHostController: NavHostController) {
+fun NavGraphBuilder.addDirectoryNav(
+    parentNavController: NavHostController,
+    navController: NavHostController
+) {
     composable<DashboardRoutes.DirectoryRoute> {
-        DirectoryScreen(navController = navHostController, viewModel = koinViewModel())
+        DirectoryScreen(
+            parentNavController = parentNavController,
+            navController = navController,
+            viewModel = koinViewModel()
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/AddContactScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/AddContactScreen.kt
@@ -1,0 +1,220 @@
+package us.docbee.docbeeapp.presentation.directory
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import docbee.composeapp.generated.resources.Res
+import docbee.composeapp.generated.resources.add_contact_app_bar_subtitle
+import docbee.composeapp.generated.resources.add_contact_app_bar_title
+import docbee.composeapp.generated.resources.add_contact_form_address_field
+import docbee.composeapp.generated.resources.add_contact_form_birth_date_field
+import docbee.composeapp.generated.resources.add_contact_form_email_field
+import docbee.composeapp.generated.resources.add_contact_form_lastname_field
+import docbee.composeapp.generated.resources.add_contact_form_name_field
+import docbee.composeapp.generated.resources.add_contact_form_phone_field
+import docbee.composeapp.generated.resources.add_contact_form_register_label
+import docbee.composeapp.generated.resources.ic_male
+import docbee.composeapp.generated.resources.modal_country_code_search_title
+import docbee.composeapp.generated.resources.modal_country_code_title
+import kotlinx.coroutines.flow.collectLatest
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import us.docbee.docbeeapp.presentation.components.PrimaryButton
+import us.docbee.docbeeapp.presentation.components.inputs.InputDateFieldText
+import us.docbee.docbeeapp.presentation.components.inputs.InputFieldText
+import us.docbee.docbeeapp.presentation.components.inputs.countrycodefield.CountrySelectorPicker
+import us.docbee.docbeeapp.presentation.components.inputs.countrycodefield.InputCountryCodeFieldText
+import us.docbee.docbeeapp.presentation.components.toolbar.Toolbar
+import us.docbee.docbeeapp.presentation.directory.effects.AddContactEffects
+import us.docbee.docbeeapp.presentation.directory.events.AddContactEvents
+import us.docbee.docbeeapp.presentation.directory.states.AddContactState
+import us.docbee.docbeeapp.presentation.theme.Black
+import us.docbee.docbeeapp.presentation.theme.Green100
+import us.docbee.docbeeapp.presentation.theme.White
+import us.docbee.docbeeapp.utils.ui.SetStatusBar
+
+@Composable
+fun AddContactScreen(navController: NavHostController, viewModel: AddContactViewModel) {
+    val uiState by viewModel.uiState.collectAsState()
+    var isCountrySelectorVisible by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        viewModel.effect.collectLatest { effect ->
+            when (effect) {
+                is AddContactEffects.NavigateBack -> navController.navigateUp()
+                is AddContactEffects.NavigateToDirectory -> navController.navigateUp()
+                is AddContactEffects.OpenCountrySelector -> isCountrySelectorVisible = true
+                is AddContactEffects.CloseCountrySelector -> isCountrySelectorVisible = false
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier
+            .windowInsetsPadding(WindowInsets.navigationBars),
+        containerColor = Black,
+        topBar = {
+            Toolbar(
+                title = Res.string.add_contact_app_bar_title,
+                subtitle = Res.string.add_contact_app_bar_subtitle,
+                isBackVisible = true,
+                onBackClicked = { viewModel.onEvent(AddContactEvents.OnBackPressed) }
+            )
+        }
+    ) { contentPadding ->
+        SetStatusBar(isDarkMode = true)
+        Column(
+            modifier = Modifier.fillMaxSize()
+                .padding(contentPadding)
+                .padding(horizontal = 54.dp)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Image(
+                modifier = Modifier.padding(vertical = 24.dp)
+                    .size(92.dp)
+                    .border(width = 2.dp, shape = CircleShape, color = White),
+                painter = painterResource(Res.drawable.ic_male),
+                colorFilter = ColorFilter.tint(color = White),
+                contentDescription = null
+            )
+            AddContactForm(
+                modifier = Modifier,
+                uiState = uiState,
+                onChangeName = { name -> viewModel.onEvent(AddContactEvents.OnChangeNameField(name))},
+                onChangeLastName = { lastname -> viewModel.onEvent(AddContactEvents.OnChangeLastNameField(lastname)) },
+                onChangeEmail = { email -> viewModel.onEvent(AddContactEvents.OnChangeEmailField(email)) },
+                onChangeDateOfBirth = { birth -> viewModel.onEvent(AddContactEvents.OnChangeDateOfBirthField(birth)) },
+                onChangePhoneNumber = { phone -> viewModel.onEvent(AddContactEvents.OnChangePhoneNumberField(phone)) },
+                onChangeAddress = { address -> viewModel.onEvent(AddContactEvents.OnChangeAddressField(address)) },
+                onCountryCodeClicked = { viewModel.onEvent(AddContactEvents.CountryCodeEvent) },
+                onSaveClick = { viewModel.onEvent(AddContactEvents.OnSaveClick) }
+            )
+            CountrySelectorPicker(
+                isVisible = isCountrySelectorVisible,
+                searchValue = uiState.phoneState.searchCountryValue,
+                title = stringResource(Res.string.modal_country_code_title),
+                placeholder = stringResource(Res.string.modal_country_code_search_title),
+                countries = uiState.phoneState.countries,
+                onSearchValueChange = { search ->
+                    viewModel.onEvent(AddContactEvents.OnChangeSearchField(search))
+                },
+                onDismiss = { viewModel.onEvent(AddContactEvents.CloseCountryCodeEvent) },
+                onCountrySelect = { country -> viewModel.onEvent(AddContactEvents.OnCountryCodeField(country)) }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddContactForm(
+    modifier: Modifier = Modifier,
+    uiState: AddContactState,
+    onChangeName: (String) -> Unit,
+    onChangeLastName: (String) -> Unit,
+    onChangeEmail: (String) -> Unit,
+    onChangeDateOfBirth: (Long) -> Unit,
+    onChangePhoneNumber: (String) -> Unit,
+    onChangeAddress: (String) -> Unit,
+    onSaveClick: () -> Unit,
+    onCountryCodeClicked: () -> Unit
+) {
+    Column(modifier = modifier) {
+        InputFieldText(
+            inputLabel = stringResource(Res.string.add_contact_form_name_field),
+            keyboardCapitalization = KeyboardCapitalization.Words,
+            focusDirection = FocusDirection.Right,
+            imeAction = ImeAction.Next,
+            value = uiState.name,
+            isError = uiState.nameError.isNotEmpty(),
+            errorLabel = uiState.nameError,
+            onValueChange = onChangeName
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        InputFieldText(
+            inputLabel = stringResource(Res.string.add_contact_form_lastname_field),
+            keyboardCapitalization = KeyboardCapitalization.Words,
+            focusDirection = FocusDirection.Down,
+            imeAction = ImeAction.Next,
+            value = uiState.lastName,
+            isError = uiState.lastNameError.isNotEmpty(),
+            errorLabel = uiState.lastNameError,
+            onValueChange = onChangeLastName
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        InputFieldText(
+            inputLabel = stringResource(Res.string.add_contact_form_email_field),
+            focusDirection = FocusDirection.Down,
+            imeAction = ImeAction.Next,
+            value = uiState.email,
+            isError = uiState.emailError.isNotEmpty(),
+            errorLabel = uiState.emailError,
+            onValueChange = onChangeEmail
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        InputDateFieldText(
+            value = uiState.dateOfBirth,
+            inputLabel = stringResource(Res.string.add_contact_form_birth_date_field),
+            isError = uiState.dateOfBirthError.isNotEmpty(),
+            errorLabel = uiState.dateOfBirthError,
+            datePickerState = rememberDatePickerState(),
+            onSelectedDate = onChangeDateOfBirth
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        InputCountryCodeFieldText(
+            state = uiState.phoneState,
+            inputLabel = stringResource(Res.string.add_contact_form_phone_field),
+            focusDirection = FocusDirection.Down,
+            imeAction = ImeAction.Next,
+            isError = uiState.phoneState.error.isNotEmpty(),
+            errorLabel = uiState.phoneState.error,
+            onChangePhoneNumber = onChangePhoneNumber,
+            onCountryCodeClicked = onCountryCodeClicked
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        InputFieldText(
+            inputLabel = stringResource(Res.string.add_contact_form_address_field),
+            value = uiState.address,
+            isError = uiState.addressError.isNotEmpty(),
+            errorLabel = uiState.addressError,
+            onValueChange = onChangeAddress,
+            imeAction = ImeAction.Done
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        PrimaryButton(
+            text = stringResource(Res.string.add_contact_form_register_label),
+            onClick = onSaveClick,
+            backgroundColor = Green100
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/AddContactViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/AddContactViewModel.kt
@@ -1,0 +1,143 @@
+package us.docbee.docbeeapp.presentation.directory
+
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import us.docbee.docbeeapp.domain.models.Country
+import us.docbee.docbeeapp.domain.models.directory.AddContactResult
+import us.docbee.docbeeapp.domain.models.signup.ContactParams
+import us.docbee.docbeeapp.domain.usecases.GetCountriesUseCase
+import us.docbee.docbeeapp.domain.usecases.SaveUserContactUseCase
+import us.docbee.docbeeapp.presentation.core.BaseViewModel
+import us.docbee.docbeeapp.presentation.directory.effects.AddContactEffects
+import us.docbee.docbeeapp.presentation.directory.events.AddContactEvents
+import us.docbee.docbeeapp.presentation.directory.states.AddContactState
+import us.docbee.docbeeapp.utils.COUNTRY_DEFAULT
+import us.docbee.docbeeapp.utils.convertMillisWithoutTimeZone
+
+class AddContactViewModel(
+    private val getCountriesUseCase: GetCountriesUseCase,
+    private val saveContactUseCase: SaveUserContactUseCase
+) : BaseViewModel<AddContactState, AddContactEvents, AddContactEffects>(AddContactState()) {
+
+    private var _fullCountries: MutableStateFlow<List<Country>> = MutableStateFlow(emptyList())
+
+    init {
+        onEvent(AddContactEvents.OnInit)
+    }
+
+    override fun onEvent(event: AddContactEvents) {
+        when (event) {
+            is AddContactEvents.OnInit -> initData()
+            is AddContactEvents.OnBackPressed -> emitEffect(AddContactEffects.NavigateBack)
+            is AddContactEvents.OnChangeNameField -> onChangeName(event.name)
+            is AddContactEvents.OnChangeLastNameField -> onChangeLastName(event.lastName)
+            is AddContactEvents.OnChangeEmailField -> onChangeEmail(event.email)
+            is AddContactEvents.OnChangeDateOfBirthField -> onChangeDateOfBirth(event.dateOfBirth)
+            is AddContactEvents.OnChangePhoneNumberField -> onChangePhoneNumber(event.phoneNumber)
+            is AddContactEvents.OnCountryCodeField -> onChangeCountryCode(event.country)
+            is AddContactEvents.OnChangeAddressField -> onChangeAddress(event.address)
+            is AddContactEvents.OnSaveClick -> performSaveContact()
+            is AddContactEvents.CountryCodeEvent -> emitEffect(AddContactEffects.OpenCountrySelector)
+            is AddContactEvents.CloseCountryCodeEvent -> onResetCountryCodeSelector()
+            is AddContactEvents.OnChangeSearchField -> onSearchCountry(event.search)
+        }
+    }
+
+    private fun initData() {
+        viewModelScope.launch {
+            val response = getCountriesUseCase.fetchCountries()
+            updateState {
+                copy(
+                    phoneState = phoneState.copy(
+                        countries = response,
+                        selectedCountry = response.find { it.isoCode == COUNTRY_DEFAULT }
+                    )
+                )
+            }
+            _fullCountries.value = response
+        }
+    }
+
+    private fun onChangeName(name: String) {
+        updateState { copy(name = name, nameError = "") }
+    }
+
+    private fun onChangeLastName(lastName: String) {
+        updateState { copy(lastName = lastName, lastNameError = "") }
+    }
+
+    private fun onChangeEmail(email: String) {
+        updateState { copy(email = email, emailError = "") }
+    }
+
+    private fun onChangeDateOfBirth(dateOfBirth: Long) {
+        val dateOfBirthFormatted = convertMillisWithoutTimeZone(dateOfBirth)
+        updateState { copy(dateOfBirth = dateOfBirthFormatted, dateOfBirthError = "") }
+    }
+
+    private fun onChangePhoneNumber(phoneNumber: String) {
+        updateState {
+            copy(
+                phoneState = phoneState.copy(phoneNumber = phoneNumber, error = "")
+            )
+        }
+    }
+
+    private fun onChangeCountryCode(country: Country) {
+        updateState {
+            copy(
+                phoneState = phoneState.copy(selectedCountry = country)
+            )
+        }
+        onSearchCountry("")
+        emitEffect(AddContactEffects.CloseCountrySelector)
+    }
+
+    private fun onSearchCountry(search: String) {
+        val filteredList = if (search.isEmpty()) {
+            _fullCountries.value
+        } else {
+            _fullCountries.value
+                .filter {
+                    it.callingCode.contains(search, ignoreCase = true)
+                            || it.name.contains(search, ignoreCase = true)
+                }
+        }
+        updateState {
+            copy(
+                phoneState = phoneState.copy(
+                    countries = filteredList,
+                    searchCountryValue = search
+                )
+            )
+        }
+    }
+
+    private fun onChangeAddress(address: String) {
+        updateState { copy(address = address, addressError = "") }
+    }
+
+    private fun onResetCountryCodeSelector() {
+        onSearchCountry("")
+        emitEffect(AddContactEffects.CloseCountrySelector)
+    }
+
+    private fun performSaveContact() {
+        viewModelScope.launch {
+            val state = uiState.value
+            val contactParam = ContactParams(
+                name = state.name,
+                lastName = state.lastName,
+                email = state.email,
+                dateOfBirth = state.dateOfBirth,
+                phoneNumber = "${state.phoneState.selectedCountry?.callingCode}${state.phoneState.phoneNumber}",
+                address = state.address
+            )
+            when (val response = saveContactUseCase.saveUserContact(contactParam)) {
+                is AddContactResult.Success -> emitEffect(AddContactEffects.NavigateToDirectory)
+                else -> Unit
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/DirectoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/DirectoryScreen.kt
@@ -1,58 +1,97 @@
 package us.docbee.docbeeapp.presentation.directory
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AddCircleOutline
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.TestOnly
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import docbee.composeapp.generated.resources.Res
 import docbee.composeapp.generated.resources.general_label_search
+import kotlinx.coroutines.flow.collectLatest
 import org.jetbrains.compose.resources.stringResource
 import us.docbee.docbeeapp.presentation.components.ContactCard
 import us.docbee.docbeeapp.presentation.components.SwipeState
 import us.docbee.docbeeapp.presentation.components.inputs.InputSearchField
+import us.docbee.docbeeapp.presentation.directory.effects.DirectoryEffects
 import us.docbee.docbeeapp.presentation.directory.events.DirectoryEvents
 import us.docbee.docbeeapp.presentation.directory.states.ContactState
+import us.docbee.docbeeapp.presentation.navigation.AddContactRoute
 import us.docbee.docbeeapp.presentation.theme.White
 
 @Composable
-fun DirectoryScreen(navController: NavHostController, viewModel: DirectoryViewModel) {
+fun DirectoryScreen(
+    parentNavController: NavHostController,
+    navController: NavHostController,
+    viewModel: DirectoryViewModel
+) {
     val state by viewModel.uiState.collectAsState()
-    Column(
-        modifier = Modifier.fillMaxSize()
-            .padding(vertical = 24.dp, horizontal = 48.dp)
-    ) {
-        InputSearchField(
-            modifier = Modifier.fillMaxWidth(),
-            placeholder = stringResource(Res.string.general_label_search),
-            value = state.contactSearch,
-            onValueChange = { search -> viewModel.onEvent(DirectoryEvents.OnSearchEvent(search)) }
-        )
-        Spacer(modifier = Modifier.height(24.dp))
-        when {
-            state.isError -> Text("Error", color = White) // TODO -> It will change in further PRs
-            state.contacts.isEmpty() -> Text("Empty State", color = White) // TODO -> It will change in further PRs
-            else -> {
-                ContactList(
-                    contacts = state.contacts,
-                    onArchive = { uid -> viewModel.onEvent(DirectoryEvents.OnArchiveContactEvent(uid)) },
-                    onDelete = { uid -> viewModel.onEvent(DirectoryEvents.OnDeleteContactEvent(uid)) },
-                    onClick = { uid -> viewModel.onEvent(DirectoryEvents.OnClickContactEvent(uid)) },
-                    onSwipeChange = { uid, swipe -> viewModel.onEvent(DirectoryEvents.OnSwipeContactEvent(uid, swipe)) }
-                )
+
+    LaunchedEffect(Unit) {
+        viewModel.onEvent(DirectoryEvents.OnInitEvent)
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.effect.collectLatest { effect ->
+            when (effect) {
+                is DirectoryEffects.NavigateToAddContact -> parentNavController.navigate(AddContactRoute)
             }
         }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier.fillMaxSize()
+                .padding(vertical = 24.dp, horizontal = 48.dp)
+        ) {
+            InputSearchField(
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = stringResource(Res.string.general_label_search),
+                value = state.contactSearch,
+                onValueChange = { search -> viewModel.onEvent(DirectoryEvents.OnSearchEvent(search)) }
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            when {
+                state.isError -> Text("Error", color = White) // TODO -> It will change in further PRs
+                state.contacts.isEmpty() -> Text("Empty State", color = White) // TODO -> It will change in further PRs
+                else -> {
+                    ContactList(
+                        contacts = state.contacts,
+                        onArchive = { uid -> viewModel.onEvent(DirectoryEvents.OnArchiveContactEvent(uid)) },
+                        onDelete = { uid -> viewModel.onEvent(DirectoryEvents.OnDeleteContactEvent(uid)) },
+                        onClick = { uid -> viewModel.onEvent(DirectoryEvents.OnClickContactEvent(uid)) },
+                        onSwipeChange = { uid, swipe -> viewModel.onEvent(DirectoryEvents.OnSwipeContactEvent(uid, swipe)) }
+                    )
+                }
+            }
+        }
+        Image(
+            modifier = Modifier.align(Alignment.BottomEnd)
+                .padding(end = 28.dp, bottom = 28.dp)
+                .size(42.dp)
+                .clickable { viewModel.onEvent(DirectoryEvents.OnAddContactEvent) },
+            imageVector = Icons.Outlined.AddCircleOutline,
+            colorFilter = ColorFilter.tint(color = White),
+            contentDescription = null
+        )
     }
 }
 
@@ -65,7 +104,7 @@ fun ContactList(
     onSwipeChange: (uid: String, event: SwipeState) -> Unit
 ) {
     LazyColumn {
-        itemsIndexed(items = contacts, key = {_, contact -> contact.uid}) { index, item ->
+        itemsIndexed(items = contacts, key = { _, contact -> contact.uid }) { index, item ->
             ContactCard(
                 gender = item.contact.gender,
                 fullName = "${item.contact.firstName} ${item.contact.lastName}",

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/DirectoryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/DirectoryViewModel.kt
@@ -15,10 +15,6 @@ class DirectoryViewModel(
     private val userContacts: GetUserContactsUseCase
 ) : BaseViewModel<DirectoryState, DirectoryEvents, DirectoryEffects>(DirectoryState()) {
 
-    init {
-        onEvent(DirectoryEvents.OnInitEvent)
-    }
-
     override fun onEvent(event: DirectoryEvents) {
         when (event) {
             is DirectoryEvents.OnInitEvent -> initDirectory()
@@ -27,6 +23,7 @@ class DirectoryViewModel(
             is DirectoryEvents.OnArchiveContactEvent -> archiveContact(event.uid)
             is DirectoryEvents.OnDeleteContactEvent -> deleteContact(event.uid)
             is DirectoryEvents.OnClickContactEvent -> clickContact(event.uid)
+            is DirectoryEvents.OnAddContactEvent -> emitEffect(DirectoryEffects.NavigateToAddContact)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/effects/AddContactEffects.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/effects/AddContactEffects.kt
@@ -1,0 +1,8 @@
+package us.docbee.docbeeapp.presentation.directory.effects
+
+sealed class AddContactEffects {
+    data object NavigateBack: AddContactEffects()
+    data object NavigateToDirectory: AddContactEffects()
+    data object OpenCountrySelector: AddContactEffects()
+    data object CloseCountrySelector: AddContactEffects()
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/effects/DirectoryEffects.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/effects/DirectoryEffects.kt
@@ -1,4 +1,5 @@
 package us.docbee.docbeeapp.presentation.directory.effects
 
 sealed class DirectoryEffects {
+    data object NavigateToAddContact: DirectoryEffects()
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/events/AddContactEvents.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/events/AddContactEvents.kt
@@ -1,0 +1,19 @@
+package us.docbee.docbeeapp.presentation.directory.events
+
+import us.docbee.docbeeapp.domain.models.Country
+
+sealed class AddContactEvents {
+    data object OnInit: AddContactEvents()
+    data object OnBackPressed: AddContactEvents()
+    data class OnChangeNameField(val name: String): AddContactEvents()
+    data class OnChangeLastNameField(val lastName: String): AddContactEvents()
+    data class OnChangeEmailField(val email: String): AddContactEvents()
+    data class OnChangeDateOfBirthField(val dateOfBirth: Long): AddContactEvents()
+    data class OnCountryCodeField(val country: Country): AddContactEvents()
+    data object CountryCodeEvent: AddContactEvents()
+    data object CloseCountryCodeEvent: AddContactEvents()
+    data class OnChangePhoneNumberField(val phoneNumber: String): AddContactEvents()
+    data class OnChangeAddressField(val address: String): AddContactEvents()
+    data class OnChangeSearchField(val search: String): AddContactEvents()
+    data object OnSaveClick: AddContactEvents()
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/events/DirectoryEvents.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/events/DirectoryEvents.kt
@@ -9,4 +9,5 @@ sealed class DirectoryEvents {
     data class OnArchiveContactEvent(val uid: String): DirectoryEvents()
     data class OnDeleteContactEvent(val uid: String): DirectoryEvents()
     data class OnClickContactEvent(val uid: String): DirectoryEvents()
+    data object OnAddContactEvent: DirectoryEvents()
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/states/AddContactState.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/directory/states/AddContactState.kt
@@ -1,0 +1,17 @@
+package us.docbee.docbeeapp.presentation.directory.states
+
+import us.docbee.docbeeapp.presentation.components.inputs.countrycodefield.PhoneInputState
+
+data class AddContactState(
+    var name: String = "",
+    var nameError: String = "",
+    var lastName: String = "",
+    var lastNameError: String = "",
+    var email: String = "",
+    var emailError: String = "",
+    var dateOfBirth: String = "",
+    var dateOfBirthError: String = "",
+    var address: String = "",
+    var addressError: String = "",
+    var phoneState: PhoneInputState = PhoneInputState()
+)

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/AppNavigator.kt
@@ -3,6 +3,7 @@ package us.docbee.docbeeapp.presentation.navigation
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
+import us.docbee.docbeeapp.presentation.navigation.routes.addContactNav
 import us.docbee.docbeeapp.presentation.navigation.routes.addDashboardNav
 import us.docbee.docbeeapp.presentation.navigation.routes.addLoginNav
 
@@ -15,5 +16,6 @@ fun AppNavigator() {
     ) {
         addLoginNav(navController)
         addDashboardNav(navController)
+        addContactNav(navController)
     }
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/NavigationRoutes.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/NavigationRoutes.kt
@@ -7,3 +7,6 @@ data object AuthenticationRoute
 
 @Serializable
 data object DashboardRoute
+
+@Serializable
+data object AddContactRoute

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/routes/AddContactRoute.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/navigation/routes/AddContactRoute.kt
@@ -1,0 +1,14 @@
+package us.docbee.docbeeapp.presentation.navigation.routes
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import org.koin.compose.viewmodel.koinViewModel
+import us.docbee.docbeeapp.presentation.directory.AddContactScreen
+import us.docbee.docbeeapp.presentation.navigation.AddContactRoute
+
+fun NavGraphBuilder.addContactNav(navController: NavHostController) {
+    composable<AddContactRoute> {
+        AddContactScreen(navController = navController, viewModel = koinViewModel())
+    }
+}


### PR DESCRIPTION
# Add Contact Creation Form and Navigation

## Description

This PR introduces a new **form** that allows users to create contacts, along with navigation updates to integrate the flow into the app.

### Key Features

- ✅ **Create Contact Form**
  - Input fields for name, email, and phone number.
  - Basic validation (required fields, email format, etc.).
  - UI built with Jetpack Compose and integrated with ViewModel.

- ✅ **Navigation Integration**
  - Added a route for **Create Contact** in the `AppNavigator`.
  - Navigation from the Directory screen to the form.
  - Returns to the Directory screen after a contact is successfully created.

- ✅ **Firestore Integration**
  - Saves new contacts to the `contacts` collection under the authenticated user.
  - Updates Directory screen automatically with the new contact.

## Visual Evidence

https://github.com/user-attachments/assets/715028d0-22ab-4474-9a03-d948681151c9

