### PR TITLE
feat: Add Location Permission Manager

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/MainActivity.kt
@@ -4,11 +4,18 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import org.koin.android.ext.android.inject
+import us.docbee.docbeeapp.utils.ui.permissions.AndroidLocationPermissionManager
+import us.docbee.docbeeapp.utils.ui.permissions.LocationPermissionManager
 
 class MainActivity : ComponentActivity() {
+
+    private val locationManager: LocationPermissionManager by inject<LocationPermissionManager>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        (locationManager as AndroidLocationPermissionManager).setActivity(this)
 
         setContent {
             App()

--- a/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/utils/ui/permissions/LocationPermissionManager.android.kt
+++ b/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/utils/ui/permissions/LocationPermissionManager.android.kt
@@ -1,0 +1,60 @@
+package us.docbee.docbeeapp.utils.ui.permissions
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+
+class AndroidLocationPermissionManager : LocationPermissionManager {
+
+    private lateinit var _activity: ComponentActivity
+    private lateinit var _callback: (PermissionResult) -> Unit
+    private lateinit var requestContactPermissionLauncher: ActivityResultLauncher<String>
+
+    private val permission = Manifest.permission.ACCESS_FINE_LOCATION
+
+    override fun isPermissionGranted(): Boolean {
+        return ContextCompat.checkSelfPermission(
+            _activity,
+            permission
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    override fun requestPermission(callback: (PermissionResult) -> Unit) {
+        when {
+            ContextCompat.checkSelfPermission(
+                _activity,
+                permission
+            ) == PackageManager.PERMISSION_GRANTED -> {
+                callback.invoke(PermissionResult.Granted)
+            }
+
+            ActivityCompat.shouldShowRequestPermissionRationale(_activity, permission) -> {
+                callback.invoke(PermissionResult.Rational)
+            }
+
+            else -> {
+                _callback = callback
+                requestContactPermissionLauncher.launch(permission)
+            }
+        }
+    }
+
+    fun setActivity(activity: ComponentActivity) {
+        _activity = activity
+        requestContactPermissionLauncher =
+            _activity.registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+                if (isGranted) {
+                    _callback.invoke(PermissionResult.Granted)
+                } else {
+                    _callback.invoke(PermissionResult.Denied)
+                }
+            }
+    }
+}
+
+actual fun provideLocationPermissionManager(): LocationPermissionManager =
+    AndroidLocationPermissionManager()

--- a/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/utils/ui/permissions/PermissionSettingsManager.android.kt
+++ b/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/utils/ui/permissions/PermissionSettingsManager.android.kt
@@ -1,0 +1,21 @@
+package us.docbee.docbeeapp.utils.ui.permissions
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import org.koin.core.context.GlobalContext
+
+class AndroidPermissionSettingsManager(private val context: Context) : PermissionSettingsManager {
+    override fun openAppSettings() {
+        val intent = Intent(
+            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+            Uri.fromParts("package", context.packageName, null)
+        )
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(intent)
+    }
+}
+
+actual fun providePermissionSettingsManager(): PermissionSettingsManager =
+    AndroidPermissionSettingsManager(GlobalContext.get().get())

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -53,6 +53,10 @@
     <string name="home_emergency_app_bar_subtitle">Please inform your family members about your emergency</string>
     <string name="home_emergency_button_title">Tap 3 times on screen to alert</string>
     <string name="home_emergency_button_description">Your 5 contacts will have your current location, and medications</string>
+    <string name="home_emergency_permission_required_title">Location Permission Required</string>
+    <string name="home_emergency_permission_required_description">This feature needs access to your location to work correctly. Please enable location permissions in your device settings. Without granting this permission, you won’t be able to continue.</string>
+    <string name="home_emergency_permission_required_button_accept">Go to Settings</string>
+    <string name="home_emergency_permission_required_button_deny">Cancel</string>
 
     <string name="home_directory_app_bar_title">Directory</string>
     <string name="home_directory_app_bar_subtitle">Please check and review your emergency contacts</string>

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
@@ -36,10 +36,12 @@ import us.docbee.docbeeapp.domain.usecases.directory.DeleteUserContactUseCase
 import us.docbee.docbeeapp.presentation.dashboard.DashboardViewModel
 import us.docbee.docbeeapp.presentation.directory.AddContactViewModel
 import us.docbee.docbeeapp.presentation.directory.DirectoryViewModel
+import us.docbee.docbeeapp.presentation.home.HomeViewModel
 import us.docbee.docbeeapp.presentation.login.LoginViewModel
 import us.docbee.docbeeapp.presentation.login.SignupViewModel
 import us.docbee.docbeeapp.presentation.settings.SettingsViewModel
 import us.docbee.docbeeapp.presentation.splash.SplashViewModel
+import us.docbee.docbeeapp.utils.ui.permissions.provideLocationPermissionManager
 
 expect val nativeModules: Module
 
@@ -70,6 +72,11 @@ val usesCasesModule = module {
     factory { LogoutUseCase(get()) }
 }
 
+
+val managersModule = module {
+    single { provideLocationPermissionManager() }
+}
+
 val viewModelsModule = module {
     viewModelOf(::SplashViewModel)
     viewModelOf(::LoginViewModel)
@@ -78,12 +85,14 @@ val viewModelsModule = module {
     viewModelOf(::DirectoryViewModel)
     viewModelOf(::AddContactViewModel)
     viewModelOf(::SettingsViewModel)
+    viewModelOf(::HomeViewModel)
 }
 
 fun initKoin(config: KoinAppDeclaration? = null) {
     startKoin {
         config?.invoke(this)
         modules(
+            managersModule,
             nativeModules,
             dataSourcesModule,
             repositoryModule,

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/DashboardNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/DashboardNavigation.kt
@@ -20,7 +20,7 @@ fun DashboardNavigation(
         startDestination = DashboardRoutes.HomeRoute,
         modifier = modifier
     ) {
-        addHomeNav(navController)
+        addHomeNav(parentNavController)
         addDirectoryNav(parentNavController = parentNavController, navController = navController)
         addSettingsNav(parentNavController)
         addHistoryNav(navController)

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/HomeNav.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/HomeNav.kt
@@ -3,11 +3,15 @@ package us.docbee.docbeeapp.presentation.dashboard.navigation.routes
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import org.koin.compose.viewmodel.koinViewModel
 import us.docbee.docbeeapp.presentation.dashboard.navigation.DashboardRoutes
 import us.docbee.docbeeapp.presentation.home.HomeScreen
 
-fun NavGraphBuilder.addHomeNav(navHostController: NavHostController) {
+fun NavGraphBuilder.addHomeNav(parentNavController: NavHostController) {
     composable<DashboardRoutes.HomeRoute> {
-        HomeScreen(navController = navHostController)
+        HomeScreen(
+            parentNavController = parentNavController,
+            viewModel = koinViewModel()
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/HomeScreen.kt
@@ -11,10 +11,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -25,17 +30,77 @@ import androidx.navigation.NavHostController
 import docbee.composeapp.generated.resources.Res
 import docbee.composeapp.generated.resources.home_emergency_button_description
 import docbee.composeapp.generated.resources.home_emergency_button_title
+import docbee.composeapp.generated.resources.home_emergency_permission_required_button_accept
+import docbee.composeapp.generated.resources.home_emergency_permission_required_button_deny
+import docbee.composeapp.generated.resources.home_emergency_permission_required_description
+import docbee.composeapp.generated.resources.home_emergency_permission_required_title
 import docbee.composeapp.generated.resources.ic_emergency_button
+import kotlinx.coroutines.flow.collectLatest
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
+import us.docbee.docbeeapp.presentation.components.PrimaryButton
+import us.docbee.docbeeapp.presentation.home.effects.HomeEffects
+import us.docbee.docbeeapp.presentation.home.events.HomeEvents
 import us.docbee.docbeeapp.presentation.theme.Green100
 import us.docbee.docbeeapp.presentation.theme.White
 import us.docbee.docbeeapp.presentation.theme.white100
+import us.docbee.docbeeapp.utils.ui.permissions.providePermissionSettingsManager
 
 @Composable
-fun HomeScreen(navController: NavHostController) {
+fun HomeScreen(
+    parentNavController: NavHostController,
+    viewModel: HomeViewModel
+) {
+
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.effect.collectLatest { effect ->
+            when (effect) {
+                is HomeEffects.NavigateToEmergency -> Unit // TODO: Navigate to Emergency
+                is HomeEffects.NavigateToSettings -> providePermissionSettingsManager().openAppSettings()
+            }
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        HomeScreenContent(onEmergencyClick = { viewModel.onEvent(HomeEvents.OnClickEmergency) })
+
+        if (uiState.shouldShowPermissionRequestModal) {
+            AlertDialog(
+                modifier = Modifier,
+                onDismissRequest = { viewModel.onEvent(HomeEvents.OnDismissSettings) },
+                title = {
+                    Text(text = stringResource(Res.string.home_emergency_permission_required_title))
+                },
+                text = {
+                    Text(text = stringResource(Res.string.home_emergency_permission_required_description))
+                },
+                confirmButton = {
+                    PrimaryButton(
+                        modifier = Modifier.wrapContentWidth(),
+                        text = stringResource(Res.string.home_emergency_permission_required_button_accept),
+                        onClick = { viewModel.onEvent(HomeEvents.OnOpenSettings) }
+                    )
+                },
+                dismissButton = {
+                    PrimaryButton(
+                        text = stringResource(Res.string.home_emergency_permission_required_button_deny),
+                        onClick = { viewModel.onEvent(HomeEvents.OnDismissSettings) }
+                    )
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun HomeScreenContent(
+    modifier: Modifier = Modifier,
+    onEmergencyClick: () -> Unit
+) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -44,7 +109,7 @@ fun HomeScreen(navController: NavHostController) {
         Box(
             modifier = Modifier.size(300.dp)
                 .clip(CircleShape)
-                .clickable { },
+                .clickable { onEmergencyClick() },
         ) {
             Box(
                 modifier = Modifier.fillMaxSize()

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/HomeViewModel.kt
@@ -1,0 +1,44 @@
+package us.docbee.docbeeapp.presentation.home
+
+import us.docbee.docbeeapp.presentation.core.BaseViewModel
+import us.docbee.docbeeapp.presentation.home.effects.HomeEffects
+import us.docbee.docbeeapp.presentation.home.events.HomeEvents
+import us.docbee.docbeeapp.presentation.home.states.UiState
+import us.docbee.docbeeapp.utils.ui.permissions.LocationPermissionManager
+import us.docbee.docbeeapp.utils.ui.permissions.PermissionResult
+
+class HomeViewModel(
+    private val permissionManager: LocationPermissionManager
+) : BaseViewModel<UiState, HomeEvents, HomeEffects>(UiState()) {
+
+    override fun onEvent(event: HomeEvents) {
+        when (event) {
+            HomeEvents.OnClickEmergency -> onClickEmergency()
+            HomeEvents.OnOpenSettings -> onOpenSettings()
+            HomeEvents.OnDismissSettings -> onDismissSettings()
+        }
+    }
+
+    private fun onClickEmergency() {
+        when {
+            permissionManager.isPermissionGranted() -> updateState { copy(shouldShowPermissionRequestModal = false) }
+            else -> {
+                permissionManager.requestPermission { permissionResult ->
+                    updateState { copy(shouldShowPermissionRequestModal = permissionResult !is PermissionResult.Granted) }
+                    if (permissionResult is PermissionResult.Granted) {
+                        emitEffect(HomeEffects.NavigateToEmergency)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun onOpenSettings() {
+        updateState { copy(shouldShowPermissionRequestModal = false) }
+        emitEffect(HomeEffects.NavigateToSettings)
+    }
+
+    private fun onDismissSettings() {
+        updateState { copy(shouldShowPermissionRequestModal = false) }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/effects/HomeEffects.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/effects/HomeEffects.kt
@@ -1,0 +1,6 @@
+package us.docbee.docbeeapp.presentation.home.effects
+
+sealed class HomeEffects {
+    data object NavigateToEmergency: HomeEffects()
+    data object NavigateToSettings: HomeEffects()
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/events/HomeEvents.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/events/HomeEvents.kt
@@ -1,0 +1,7 @@
+package us.docbee.docbeeapp.presentation.home.events
+
+sealed class HomeEvents {
+    data object OnClickEmergency: HomeEvents()
+    data object OnOpenSettings: HomeEvents()
+    data object OnDismissSettings: HomeEvents()
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/states/UiState.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/states/UiState.kt
@@ -1,0 +1,5 @@
+package us.docbee.docbeeapp.presentation.home.states
+
+data class UiState(
+    val shouldShowPermissionRequestModal: Boolean = false
+)

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/utils/ui/permissions/LocationPermissionManager.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/utils/ui/permissions/LocationPermissionManager.kt
@@ -1,0 +1,15 @@
+package us.docbee.docbeeapp.utils.ui.permissions
+
+sealed class PermissionResult {
+    data object Init: PermissionResult()
+    data object Granted: PermissionResult()
+    data object Denied: PermissionResult()
+    data object Rational: PermissionResult()
+}
+
+interface LocationPermissionManager {
+    fun isPermissionGranted() : Boolean
+    fun requestPermission(callback: (PermissionResult) -> Unit)
+}
+
+expect fun provideLocationPermissionManager(): LocationPermissionManager

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/utils/ui/permissions/PermissionsSettingManager.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/utils/ui/permissions/PermissionsSettingManager.kt
@@ -1,0 +1,7 @@
+package us.docbee.docbeeapp.utils.ui.permissions
+
+interface PermissionSettingsManager {
+    fun openAppSettings()
+}
+
+expect fun providePermissionSettingsManager(): PermissionSettingsManager

--- a/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/utils/ui/permissions/LocationPermissionManager.ios.kt
+++ b/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/utils/ui/permissions/LocationPermissionManager.ios.kt
@@ -1,0 +1,76 @@
+package us.docbee.docbeeapp.utils.ui.permissions
+
+import platform.CoreLocation.CLAuthorizationStatus
+import platform.CoreLocation.CLLocationManager
+import platform.CoreLocation.CLLocationManagerDelegateProtocol
+import platform.CoreLocation.kCLLocationAccuracyBest
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedAlways
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedWhenInUse
+import platform.CoreLocation.kCLAuthorizationStatusDenied
+import platform.CoreLocation.kCLAuthorizationStatusNotDetermined
+import platform.CoreLocation.kCLAuthorizationStatusRestricted
+import platform.darwin.NSObject
+
+class IosLocationPermissionManager : LocationPermissionManager {
+
+    private val locationManager = CLLocationManager()
+    private var _callback: ((PermissionResult) -> Unit)? = null
+
+    init {
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        locationManager.delegate = LocationDelegate { status ->
+            handleAuthorizationStatus(status)
+        }
+    }
+
+    override fun isPermissionGranted(): Boolean {
+        return CLLocationManager.authorizationStatus() == kCLAuthorizationStatusAuthorizedWhenInUse
+                || CLLocationManager.authorizationStatus() == kCLAuthorizationStatusAuthorizedAlways
+    }
+
+    override fun requestPermission(callback: (PermissionResult) -> Unit) {
+        when (CLLocationManager.authorizationStatus()) {
+            kCLAuthorizationStatusNotDetermined -> {
+                _callback = callback
+                locationManager.requestWhenInUseAuthorization()
+            }
+
+            kCLAuthorizationStatusRestricted, kCLAuthorizationStatusDenied -> {
+                callback.invoke(PermissionResult.Denied)
+            }
+
+            kCLAuthorizationStatusAuthorizedWhenInUse, kCLAuthorizationStatusAuthorizedAlways -> {
+                callback.invoke(PermissionResult.Granted)
+            }
+
+            else -> {
+                callback.invoke(PermissionResult.Denied)
+            }
+        }
+    }
+
+    private fun handleAuthorizationStatus(status: CLAuthorizationStatus) {
+        when (status) {
+            kCLAuthorizationStatusAuthorizedWhenInUse,
+            kCLAuthorizationStatusAuthorizedAlways -> _callback?.invoke(PermissionResult.Granted)
+
+            kCLAuthorizationStatusDenied,
+            kCLAuthorizationStatusRestricted -> _callback?.invoke(PermissionResult.Denied)
+        }
+    }
+
+    private class LocationDelegate(
+        private val onStatusChanged: (CLAuthorizationStatus) -> Unit
+    ) : NSObject(), CLLocationManagerDelegateProtocol {
+
+        override fun locationManager(
+            manager: CLLocationManager,
+            didChangeAuthorizationStatus: CLAuthorizationStatus
+        ) {
+            onStatusChanged(didChangeAuthorizationStatus)
+        }
+    }
+}
+
+actual fun provideLocationPermissionManager(): LocationPermissionManager =
+    IosLocationPermissionManager()

--- a/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/utils/ui/permissions/PermissionSettingsManager.ios.kt
+++ b/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/utils/ui/permissions/PermissionSettingsManager.ios.kt
@@ -1,0 +1,17 @@
+package us.docbee.docbeeapp.utils.ui.permissions
+
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationOpenSettingsURLString
+
+class IosPermissionSettingsManager : PermissionSettingsManager {
+    override fun openAppSettings() {
+        val url = NSURL(string = UIApplicationOpenSettingsURLString)
+        if (UIApplication.sharedApplication.canOpenURL(url)) {
+            UIApplication.sharedApplication.openURL(url, emptyMap<Any?, Any>(), null)
+        }
+    }
+}
+
+actual fun providePermissionSettingsManager(): PermissionSettingsManager =
+    IosPermissionSettingsManager()

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>We need your location to share it in emergencies.</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 </dict>


### PR DESCRIPTION
## 📌 Title  
Implement Location Permission Manager and Navigation to Settings  

---

## 📝 Description  
This PR introduces managers to handle requesting location permissions and provides navigation to the app settings when the user denies permission.  
This ensures a better user experience by guiding users through enabling necessary permissions for location-based features.  

---

## 🔄 Changes  
- Implemented **LocationPermissionManager** to request and check location permissions.  
- Added functionality to navigate to system **Settings** if the user denies permission. 

---

## 🎨 Visual Evidence

Android 

<img width="300" src="https://github.com/user-attachments/assets/f775789a-d636-46ed-afdb-323b2fc97ec3" />

<img width="300" src="https://github.com/user-attachments/assets/84fd796b-4287-482a-8beb-a3da28778af7" />

iOS

<img width="300" src="https://github.com/user-attachments/assets/5effacab-dbf2-4ad3-a8d9-b5b1e4153893" />

<img width="300" src="https://github.com/user-attachments/assets/81be31c9-53b2-4904-a041-3f77414cb4f0" />

