### PR TITLE
feat: Force User to have at least one emergency contact

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -58,6 +58,11 @@
     <string name="home_emergency_permission_required_button_accept">Go to Settings</string>
     <string name="home_emergency_permission_required_button_deny">Cancel</string>
 
+    <string name="home_emergency_contact_required_title">Emergency Contact Required</string>
+    <string name="home_emergency_contact_required_description">To continue, you need to add at least one emergency contact to your directory. This ensures we can notify someone on your behalf in case of an emergency.</string>
+    <string name="home_emergency_contact_required_confirm">Add Contact</string>
+    <string name="home_emergency_contact_required_cancel">Cancel</string>
+
     <string name="home_directory_app_bar_title">Directory</string>
     <string name="home_directory_app_bar_subtitle">Please check and review your emergency contacts</string>
 

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/DefaultAlert.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/DefaultAlert.kt
@@ -1,0 +1,39 @@
+package us.docbee.docbeeapp.presentation.components
+
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun DefaultAlert(
+    modifier: Modifier = Modifier,
+    title: String,
+    description: String,
+    confirmText: String,
+    cancelText: String,
+    onConfirmClick: () -> Unit,
+    onCancelClick: () -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    AlertDialog(
+        modifier = modifier,
+        onDismissRequest = onDismissRequest,
+        title = { Text(text = title) },
+        text = { Text(text = description) },
+        confirmButton = {
+            PrimaryButton(
+                modifier = Modifier.wrapContentWidth(),
+                text = confirmText,
+                onClick = onConfirmClick
+            )
+        },
+        dismissButton = {
+            PrimaryButton(
+                text = cancelText,
+                onClick = onCancelClick
+            )
+        }
+    )
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/DashboardNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/DashboardNavigation.kt
@@ -20,7 +20,7 @@ fun DashboardNavigation(
         startDestination = DashboardRoutes.HomeRoute,
         modifier = modifier
     ) {
-        addHomeNav(parentNavController)
+        addHomeNav(parentNavController = parentNavController, navController = navController)
         addDirectoryNav(parentNavController = parentNavController, navController = navController)
         addSettingsNav(parentNavController)
         addHistoryNav(navController)

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/HomeNav.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/dashboard/navigation/routes/HomeNav.kt
@@ -7,10 +7,14 @@ import org.koin.compose.viewmodel.koinViewModel
 import us.docbee.docbeeapp.presentation.dashboard.navigation.DashboardRoutes
 import us.docbee.docbeeapp.presentation.home.HomeScreen
 
-fun NavGraphBuilder.addHomeNav(parentNavController: NavHostController) {
+fun NavGraphBuilder.addHomeNav(
+    parentNavController: NavHostController,
+    navController: NavHostController
+) {
     composable<DashboardRoutes.HomeRoute> {
         HomeScreen(
             parentNavController = parentNavController,
+            navController = navController,
             viewModel = koinViewModel()
         )
     }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/HomeScreen.kt
@@ -11,9 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,6 +28,10 @@ import androidx.navigation.NavHostController
 import docbee.composeapp.generated.resources.Res
 import docbee.composeapp.generated.resources.home_emergency_button_description
 import docbee.composeapp.generated.resources.home_emergency_button_title
+import docbee.composeapp.generated.resources.home_emergency_contact_required_cancel
+import docbee.composeapp.generated.resources.home_emergency_contact_required_confirm
+import docbee.composeapp.generated.resources.home_emergency_contact_required_description
+import docbee.composeapp.generated.resources.home_emergency_contact_required_title
 import docbee.composeapp.generated.resources.home_emergency_permission_required_button_accept
 import docbee.composeapp.generated.resources.home_emergency_permission_required_button_deny
 import docbee.composeapp.generated.resources.home_emergency_permission_required_description
@@ -38,7 +40,8 @@ import docbee.composeapp.generated.resources.ic_emergency_button
 import kotlinx.coroutines.flow.collectLatest
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
-import us.docbee.docbeeapp.presentation.components.PrimaryButton
+import us.docbee.docbeeapp.presentation.components.DefaultAlert
+import us.docbee.docbeeapp.presentation.dashboard.navigation.DashboardRoutes
 import us.docbee.docbeeapp.presentation.home.effects.HomeEffects
 import us.docbee.docbeeapp.presentation.home.events.HomeEvents
 import us.docbee.docbeeapp.presentation.navigation.EmergencyRoute
@@ -50,6 +53,7 @@ import us.docbee.docbeeapp.utils.ui.permissions.providePermissionSettingsManager
 @Composable
 fun HomeScreen(
     parentNavController: NavHostController,
+    navController: NavHostController,
     viewModel: HomeViewModel
 ) {
 
@@ -60,6 +64,7 @@ fun HomeScreen(
             when (effect) {
                 is HomeEffects.NavigateToEmergency -> parentNavController.navigate(EmergencyRoute)
                 is HomeEffects.NavigateToSettings -> providePermissionSettingsManager().openAppSettings()
+                is HomeEffects.NavigateToDirectory -> navController.navigate(DashboardRoutes.DirectoryRoute)
             }
         }
     }
@@ -68,28 +73,26 @@ fun HomeScreen(
         HomeScreenContent(onEmergencyClick = { viewModel.onEvent(HomeEvents.OnClickEmergency) })
 
         if (uiState.shouldShowPermissionRequestModal) {
-            AlertDialog(
-                modifier = Modifier,
+            DefaultAlert(
+                title = stringResource(Res.string.home_emergency_permission_required_title),
+                description = stringResource(Res.string.home_emergency_permission_required_description),
+                confirmText = stringResource(Res.string.home_emergency_permission_required_button_accept),
+                cancelText = stringResource(Res.string.home_emergency_permission_required_button_deny),
                 onDismissRequest = { viewModel.onEvent(HomeEvents.OnDismissSettings) },
-                title = {
-                    Text(text = stringResource(Res.string.home_emergency_permission_required_title))
-                },
-                text = {
-                    Text(text = stringResource(Res.string.home_emergency_permission_required_description))
-                },
-                confirmButton = {
-                    PrimaryButton(
-                        modifier = Modifier.wrapContentWidth(),
-                        text = stringResource(Res.string.home_emergency_permission_required_button_accept),
-                        onClick = { viewModel.onEvent(HomeEvents.OnOpenSettings) }
-                    )
-                },
-                dismissButton = {
-                    PrimaryButton(
-                        text = stringResource(Res.string.home_emergency_permission_required_button_deny),
-                        onClick = { viewModel.onEvent(HomeEvents.OnDismissSettings) }
-                    )
-                }
+                onConfirmClick = { viewModel.onEvent(HomeEvents.OnOpenSettings) },
+                onCancelClick = { viewModel.onEvent(HomeEvents.OnDismissSettings) }
+            )
+        }
+
+        if (uiState.showContactMissing) {
+            DefaultAlert(
+                title = stringResource(Res.string.home_emergency_contact_required_title),
+                description = stringResource(Res.string.home_emergency_contact_required_description),
+                confirmText = stringResource(Res.string.home_emergency_contact_required_confirm),
+                cancelText = stringResource(Res.string.home_emergency_contact_required_cancel),
+                onDismissRequest = { viewModel.onEvent(HomeEvents.OnCancelContacts) },
+                onConfirmClick = { viewModel.onEvent(HomeEvents.OnClickContacts) },
+                onCancelClick = { viewModel.onEvent(HomeEvents.OnCancelContacts) }
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/HomeViewModel.kt
@@ -1,5 +1,9 @@
 package us.docbee.docbeeapp.presentation.home
 
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import us.docbee.docbeeapp.domain.models.directory.ContactResult
+import us.docbee.docbeeapp.domain.usecases.GetUserContactsUseCase
 import us.docbee.docbeeapp.presentation.core.BaseViewModel
 import us.docbee.docbeeapp.presentation.home.effects.HomeEffects
 import us.docbee.docbeeapp.presentation.home.events.HomeEvents
@@ -8,7 +12,8 @@ import us.docbee.docbeeapp.utils.ui.permissions.LocationPermissionManager
 import us.docbee.docbeeapp.utils.ui.permissions.PermissionResult
 
 class HomeViewModel(
-    private val permissionManager: LocationPermissionManager
+    private val permissionManager: LocationPermissionManager,
+    private val fetchContactsUseCase: GetUserContactsUseCase
 ) : BaseViewModel<UiState, HomeEvents, HomeEffects>(UiState()) {
 
     override fun onEvent(event: HomeEvents) {
@@ -16,6 +21,11 @@ class HomeViewModel(
             HomeEvents.OnClickEmergency -> onClickEmergency()
             HomeEvents.OnOpenSettings -> onOpenSettings()
             HomeEvents.OnDismissSettings -> onDismissSettings()
+            HomeEvents.OnClickContacts -> {
+                updateState { copy(showContactMissing = false) }
+                emitEffect(HomeEffects.NavigateToDirectory)
+            }
+            HomeEvents.OnCancelContacts -> updateState { copy(showContactMissing = false) }
         }
     }
 
@@ -23,15 +33,29 @@ class HomeViewModel(
         when {
             permissionManager.isPermissionGranted() -> {
                 updateState { copy(shouldShowPermissionRequestModal = false) }
-                emitEffect(HomeEffects.NavigateToEmergency)
+                validateUserContacts { emitEffect(HomeEffects.NavigateToEmergency) }
             }
             else -> {
                 permissionManager.requestPermission { permissionResult ->
                     updateState { copy(shouldShowPermissionRequestModal = permissionResult !is PermissionResult.Granted) }
                     if (permissionResult is PermissionResult.Granted) {
-                        emitEffect(HomeEffects.NavigateToEmergency)
+                        validateUserContacts { emitEffect(HomeEffects.NavigateToEmergency) }
                     }
                 }
+            }
+        }
+    }
+
+    private fun validateUserContacts(callback: () -> Unit) {
+        viewModelScope.launch {
+            val contacts = fetchContactsUseCase.fetchUserContacts()
+            when (contacts) {
+                is ContactResult.Success -> {
+                    updateState { copy(showContactMissing = false) }
+                    callback()
+                }
+                is ContactResult.Empty -> updateState { copy(showContactMissing = true) }
+                else -> Unit // TODO: Add Error State
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/effects/HomeEffects.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/effects/HomeEffects.kt
@@ -3,4 +3,5 @@ package us.docbee.docbeeapp.presentation.home.effects
 sealed class HomeEffects {
     data object NavigateToEmergency: HomeEffects()
     data object NavigateToSettings: HomeEffects()
+    data object NavigateToDirectory: HomeEffects()
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/events/HomeEvents.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/events/HomeEvents.kt
@@ -4,4 +4,6 @@ sealed class HomeEvents {
     data object OnClickEmergency: HomeEvents()
     data object OnOpenSettings: HomeEvents()
     data object OnDismissSettings: HomeEvents()
+    data object OnClickContacts: HomeEvents()
+    data object OnCancelContacts: HomeEvents()
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/states/UiState.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/home/states/UiState.kt
@@ -1,5 +1,6 @@
 package us.docbee.docbeeapp.presentation.home.states
 
 data class UiState(
-    val shouldShowPermissionRequestModal: Boolean = false
+    val shouldShowPermissionRequestModal: Boolean = false,
+    val showContactMissing: Boolean = false
 )


### PR DESCRIPTION
## 📌 Title  
Validate Emergency Notification Flow Requires at Least One Contact  

---

## 📝 Description  
This PR introduces a validation step in the Emergency Notification flow to ensure that the user has at least one emergency contact before proceeding.  
This prevents invalid emergency requests and improves overall user experience and reliability.  

---

## 🎨 Visual Evidence

Android 

<img width="300" src="https://github.com/user-attachments/assets/7d9667f0-426c-4b6f-b16e-09f3612d5365" />

iOS

<img width="300" src="https://github.com/user-attachments/assets/c98bfc81-efc1-4a26-b04c-5c91f6b71290" />


