### PR TITLE
feat: Add Swipeable Alert Items with Delete and Edit Options  

### DIFF
--- a/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.android.kt
+++ b/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.android.kt
@@ -3,6 +3,7 @@ package us.docbee.docbeeapp.data.datasources
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 import us.docbee.docbeeapp.data.entities.alerts.AlertFetchResponse
+import us.docbee.docbeeapp.data.entities.alerts.AlertSaveResponse
 import us.docbee.docbeeapp.data.entities.alerts.AlertsDeleteResponse
 import us.docbee.docbeeapp.domain.models.alerts.AlertModel
 import us.docbee.docbeeapp.utils.FIRESTORE_COLLECTION_ALERTS
@@ -12,18 +13,24 @@ class AndroidAlertsRemoteDataSource : AlertsRemoteDataSource {
 
     private val db = FirebaseFirestore.getInstance()
 
-    override suspend fun saveAlert(uid: String, alert: AlertModel) {
-        val reference = db
-            .collection(FIRESTORE_COLLECTION_USER)
-            .document(uid)
-            .collection(FIRESTORE_COLLECTION_ALERTS)
-            .document()
+    override suspend fun saveAlert(uid: String, alert: AlertModel): AlertSaveResponse {
+        return try {
+            val reference = db
+                .collection(FIRESTORE_COLLECTION_USER)
+                .document(uid)
+                .collection(FIRESTORE_COLLECTION_ALERTS)
+                .document()
 
-        alert.uid = reference.id
+            alert.uid = reference.id
 
-        reference
-            .set(alert)
-            .await()
+            reference
+                .set(alert)
+                .await()
+
+            AlertSaveResponse(alert = alert)
+        } catch (ex: Exception) {
+            AlertSaveResponse(errorCode = "UNKNOWN_ERROR", errorMessage = ex.localizedMessage)
+        }
     }
 
     override suspend fun fetchAlert(uid: String): AlertFetchResponse {

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -77,6 +77,8 @@
     <string name="alerts_item_dizzy_description">I’m currently not feeling well and I have a lot of pain</string>
     <string name="alerts_item_accident_title">Accident</string>
     <string name="alerts_item_accident_description">I’m driving and I hit someone</string>
+    <string name="alerts_item_delete_alert">Delete</string>
+    <string name="alerts_item_edit_alert">Edit</string>
 
     <string name="alerts_add_alerts_title">Add New Alert</string>
     <string name="alerts_add_alerts_description">Let’s add new alerts and let’s add a new message to this alert to ensure we can inform your love ones in case of an emergency</string>
@@ -106,6 +108,7 @@
     <string name="settings_location_title">Location</string>
     <string name="settings_location_description">Allow others to visualize your current location</string>
     <string name="settings_logout_title">Logout</string>
+    <string name="settings_logout_description">User is requesting to sign-out from his/her session</string>
 
     <string name="emergency_toolbar_title">Sharing My Location</string>
     <string name="emergency_bottom_sheet_title">Emergency Calling</string>

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.kt
@@ -1,11 +1,12 @@
 package us.docbee.docbeeapp.data.datasources
 
 import us.docbee.docbeeapp.data.entities.alerts.AlertFetchResponse
+import us.docbee.docbeeapp.data.entities.alerts.AlertSaveResponse
 import us.docbee.docbeeapp.data.entities.alerts.AlertsDeleteResponse
 import us.docbee.docbeeapp.domain.models.alerts.AlertModel
 
 interface AlertsRemoteDataSource {
-    suspend fun saveAlert(uid: String, alert: AlertModel)
+    suspend fun saveAlert(uid: String, alert: AlertModel): AlertSaveResponse
     suspend fun fetchAlert(uid: String): AlertFetchResponse
     suspend fun deleteAlert(uid: String, alertUid: String): AlertsDeleteResponse
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/entities/alerts/AlertSaveResponse.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/entities/alerts/AlertSaveResponse.kt
@@ -1,0 +1,9 @@
+package us.docbee.docbeeapp.data.entities.alerts
+
+import us.docbee.docbeeapp.domain.models.alerts.AlertModel
+
+data class AlertSaveResponse(
+    val alert: AlertModel? = null,
+    val errorCode: String? = null,
+    val errorMessage: String? = null
+)

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/repositories/AlertsDataRepository.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/repositories/AlertsDataRepository.kt
@@ -3,6 +3,7 @@ package us.docbee.docbeeapp.data.repositories
 import us.docbee.docbeeapp.data.datasources.AlertsRemoteDataSource
 import us.docbee.docbeeapp.domain.managers.AlertsStringsManager
 import us.docbee.docbeeapp.domain.mappers.toAlertDomain
+import us.docbee.docbeeapp.domain.models.alerts.AddAlertResult
 import us.docbee.docbeeapp.domain.models.alerts.AlertModel
 import us.docbee.docbeeapp.domain.models.alerts.DeleteAlertResult
 import us.docbee.docbeeapp.domain.models.alerts.FetchAlertsResult
@@ -24,8 +25,12 @@ class AlertsDataRepository(
         return FetchAlertsResult.Success(alertList)
     }
 
-    override suspend fun saveAlerts(uid: String, alert: AlertModel) {
-        alertDataSource.saveAlert(uid, alert)
+    override suspend fun saveAlerts(uid: String, alert: AlertModel): AddAlertResult {
+        val response = alertDataSource.saveAlert(uid, alert)
+        return when {
+            response.alert != null -> AddAlertResult.Success(response.alert)
+            else -> AddAlertResult.Error
+        }
     }
 
     override suspend fun deleteAlert(
@@ -34,7 +39,7 @@ class AlertsDataRepository(
     ): DeleteAlertResult {
         val response = alertDataSource.deleteAlert(uid, alertUid)
         return when {
-            response.errorCode != null -> DeleteAlertResult.Success
+            response.errorCode != null -> DeleteAlertResult.Error
             else -> DeleteAlertResult.Success
         }
     }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
@@ -48,6 +48,7 @@ import us.docbee.docbeeapp.domain.usecases.LogoutUseCase
 import us.docbee.docbeeapp.domain.usecases.NotifyEmergencyUseCase
 import us.docbee.docbeeapp.domain.usecases.SaveUserContactUseCase
 import us.docbee.docbeeapp.domain.usecases.SendEmergencyUseCase
+import us.docbee.docbeeapp.domain.usecases.alerts.DeleteAlertsUseCase
 import us.docbee.docbeeapp.domain.usecases.alerts.SaveAlertsUseCase
 import us.docbee.docbeeapp.domain.usecases.directory.DeleteUserContactUseCase
 import us.docbee.docbeeapp.presentation.alerts.AlertsViewModel
@@ -101,6 +102,7 @@ val usesCasesModule = module {
     factory { NotifyEmergencyUseCase(get(), get(), get()) }
     factory { GetAlertsUseCase(get(), get()) }
     factory { SaveAlertsUseCase(get(), get()) }
+    factory { DeleteAlertsUseCase(get(), get()) }
 }
 
 

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/alerts/AddAlertResult.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/alerts/AddAlertResult.kt
@@ -1,7 +1,7 @@
 package us.docbee.docbeeapp.domain.models.alerts
 
 sealed class AddAlertResult {
-    data object Success: AddAlertResult()
+    data class Success(val alert: AlertModel): AddAlertResult()
     data object Error: AddAlertResult()
     data object Unauthorized: AddAlertResult()
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/repositories/AlertsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/repositories/AlertsRepository.kt
@@ -1,11 +1,12 @@
 package us.docbee.docbeeapp.domain.repositories
 
+import us.docbee.docbeeapp.domain.models.alerts.AddAlertResult
 import us.docbee.docbeeapp.domain.models.alerts.AlertModel
 import us.docbee.docbeeapp.domain.models.alerts.DeleteAlertResult
 import us.docbee.docbeeapp.domain.models.alerts.FetchAlertsResult
 
 interface AlertsRepository {
     suspend fun fetchAlerts(uid: String): FetchAlertsResult
-    suspend fun saveAlerts(uid: String, alert: AlertModel)
+    suspend fun saveAlerts(uid: String, alert: AlertModel): AddAlertResult
     suspend fun deleteAlert(uid: String, alertUid: String): DeleteAlertResult
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/usecases/alerts/DeleteAlertsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/usecases/alerts/DeleteAlertsUseCase.kt
@@ -1,23 +1,20 @@
 package us.docbee.docbeeapp.domain.usecases.alerts
 
-import us.docbee.docbeeapp.domain.mappers.toAlertModel
-import us.docbee.docbeeapp.domain.models.alerts.AddAlertResult
-import us.docbee.docbeeapp.domain.models.alerts.AlertParams
+import us.docbee.docbeeapp.domain.models.alerts.DeleteAlertResult
 import us.docbee.docbeeapp.domain.models.directory.UserUidResult
 import us.docbee.docbeeapp.domain.repositories.AlertsRepository
 import us.docbee.docbeeapp.domain.repositories.UserRepository
 
-class SaveAlertsUseCase(
+class DeleteAlertsUseCase(
     private val alertsRepository: AlertsRepository,
     private val userRepository: UserRepository
 ) {
-
-    suspend fun saveAlert(alert: AlertParams): AddAlertResult {
+    suspend fun deleteAlert(uid: String): DeleteAlertResult {
         val userResponse = userRepository.fetchUserId()
         if (userResponse !is UserUidResult.Success) {
-            return AddAlertResult.Unauthorized
+            return DeleteAlertResult.Unauthorized
         }
 
-        return alertsRepository.saveAlerts(userResponse.uid, alert.toAlertModel())
+        return alertsRepository.deleteAlert(userResponse.uid, uid)
     }
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/AlertsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/AlertsScreen.kt
@@ -39,6 +39,7 @@ import docbee.composeapp.generated.resources.alerts_add_alerts_save_button
 import docbee.composeapp.generated.resources.alerts_add_alerts_title
 import kotlinx.coroutines.flow.collectLatest
 import org.jetbrains.compose.resources.stringResource
+import us.docbee.docbeeapp.presentation.alerts.effects.AlertsEffects
 import us.docbee.docbeeapp.presentation.alerts.events.AlertsEvents
 import us.docbee.docbeeapp.presentation.components.CardDescriptionItem
 import us.docbee.docbeeapp.presentation.components.FloatingButton
@@ -62,7 +63,9 @@ fun AlertsScreen(
 
     LaunchedEffect(Unit) {
         viewModel.effect.collectLatest { effect ->
-
+            when (effect) {
+                is AlertsEffects.NavigateEditAlert -> Unit // TODO: Navigate to Edit Alert
+            }
         }
     }
 
@@ -75,10 +78,16 @@ fun AlertsScreen(
             LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 items(uiState.alerts, key = { it.uid }) { alert ->
                     CardDescriptionItem(
-                        title = alert.name,
-                        description = alert.message,
-                        icon = alert.icon.getDrawable(),
-                        onClick = { viewModel.onEvent(AlertsEvents.OnClickAlert(alert.uid)) }
+                        title = alert.alert.name,
+                        description = alert.alert.message,
+                        icon = alert.alert.icon.getDrawable(),
+                        onClick = { viewModel.onEvent(AlertsEvents.OnClickAlert(alert.uid)) },
+                        onDeleteClick = { viewModel.onEvent(AlertsEvents.OnDeleteAlert(alert.uid)) },
+                        isSwipeable = alert.isSwipeable,
+                        swipeState = alert.swipeState,
+                        onSwipeChanged = {
+                            viewModel.onEvent(AlertsEvents.OnSwipeAlertEvent(alert.uid, it))
+                        }
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/AlertsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/AlertsViewModel.kt
@@ -4,17 +4,22 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 import us.docbee.docbeeapp.domain.models.alerts.AddAlertResult
 import us.docbee.docbeeapp.domain.models.alerts.AlertParams
+import us.docbee.docbeeapp.domain.models.alerts.DeleteAlertResult
 import us.docbee.docbeeapp.domain.models.alerts.FetchAlertsResult
+import us.docbee.docbeeapp.domain.usecases.alerts.DeleteAlertsUseCase
 import us.docbee.docbeeapp.domain.usecases.alerts.GetAlertsUseCase
 import us.docbee.docbeeapp.domain.usecases.alerts.SaveAlertsUseCase
 import us.docbee.docbeeapp.presentation.alerts.effects.AlertsEffects
 import us.docbee.docbeeapp.presentation.alerts.events.AlertsEvents
+import us.docbee.docbeeapp.presentation.alerts.states.AlertState
 import us.docbee.docbeeapp.presentation.alerts.states.UiState
+import us.docbee.docbeeapp.presentation.components.HorizontalSwipeState
 import us.docbee.docbeeapp.presentation.core.BaseViewModel
 
 class AlertsViewModel(
     private val getAlertsUseCase: GetAlertsUseCase,
-    private val saveAlertsUseCase: SaveAlertsUseCase
+    private val saveAlertsUseCase: SaveAlertsUseCase,
+    private val deleteAlertsUseCase: DeleteAlertsUseCase
 ) : BaseViewModel<UiState, AlertsEvents, AlertsEffects>(UiState()) {
 
     init {
@@ -26,15 +31,31 @@ class AlertsViewModel(
             is AlertsEvents.OnInit -> onInitAlerts()
             is AlertsEvents.OnClickAddAlert -> onCLickAddAlert()
             is AlertsEvents.OnClickCloseAddAlert -> onClickCloseAddAlert()
-            is AlertsEvents.OnClickAlert -> onAlertClicked()
+            is AlertsEvents.OnClickAlert -> onAlertClicked(event.uid)
             is AlertsEvents.OnSaveAlert -> onSaveAlertClicked(event.name, event.message)
+            is AlertsEvents.OnDeleteAlert -> onDeleteAlertClicked(event.uid)
+            is AlertsEvents.OnEditAlert -> onEditAlertClicked(event.uid)
+            is AlertsEvents.OnSwipeAlertEvent -> onSwipeAlertEvent(event.uid, event.swipeState)
         }
     }
 
     private fun onInitAlerts() {
         viewModelScope.launch {
             when (val alertsResult = getAlertsUseCase.fetchAlerts()) {
-                is FetchAlertsResult.Success -> updateState { copy(alerts = alertsResult.alerts) }
+                is FetchAlertsResult.Success -> {
+                    updateState {
+                        copy(
+                            alerts = alertsResult.alerts.mapIndexed { index, alert ->
+                                AlertState(
+                                    uid = alert.uid,
+                                    alert = alert,
+                                    isSwipeable = index > 3
+                                )
+                            }
+                        )
+                    }
+                }
+
                 is FetchAlertsResult.Error -> Unit // TODO: Add error state screen
             }
         }
@@ -48,17 +69,68 @@ class AlertsViewModel(
         updateState { copy(isAddingAlert = false) }
     }
 
-    private fun onAlertClicked() {
-        // TODO: Implement Functionality
+    private fun onAlertClicked(uid: String) {
+        updateState {
+            copy(
+                alerts = alerts.map { item ->
+                    if (item.uid == uid) {
+                        item.copy(swipeState = HorizontalSwipeState.Closed)
+                    } else {
+                        item
+                    }
+                }
+            )
+        }
     }
 
     private fun onSaveAlertClicked(name: String, message: String) {
         viewModelScope.launch {
-            val params = AlertParams(name = name, message = message, icon = "DEFAULT")
-            when(val alertsResult = saveAlertsUseCase.saveAlert(params)) {
-                is AddAlertResult.Success -> updateState { copy(isAddingAlert = false) }
+            val params =
+                AlertParams(name = name, message = message, icon = "DEFAULT") // TODO: Add icon
+            when (val alertsResult = saveAlertsUseCase.saveAlert(params)) {
+                is AddAlertResult.Success -> {
+                    updateState {
+                        copy(
+                            isAddingAlert = false,
+                            alerts = alerts + AlertState(
+                                uid = alertsResult.alert.uid,
+                                alert = alertsResult.alert,
+                                isSwipeable = true
+                            )
+                        )
+                    }
+                }
+
                 is AddAlertResult.Error, is AddAlertResult.Unauthorized -> Unit
             }
+        }
+    }
+
+    private fun onDeleteAlertClicked(uid: String) {
+        viewModelScope.launch {
+            when (deleteAlertsUseCase.deleteAlert(uid)) {
+                is DeleteAlertResult.Success -> updateState { copy(alerts = alerts.filter { it.uid != uid }) }
+                is DeleteAlertResult.Error, is DeleteAlertResult.Unauthorized -> Unit
+            }
+        }
+    }
+
+    private fun onEditAlertClicked(uid: String) {
+        emitEffect(AlertsEffects.NavigateEditAlert(uid))
+    }
+
+    private fun onSwipeAlertEvent(uid: String, state: HorizontalSwipeState) {
+        updateState {
+            copy(
+                alerts = alerts.map { item ->
+                    when {
+                        item.uid == uid -> item.copy(swipeState = state)
+                        state == HorizontalSwipeState.OpenLeft -> item.copy(swipeState = HorizontalSwipeState.Closed)
+                        state == HorizontalSwipeState.OpenRight -> item.copy(swipeState = HorizontalSwipeState.Closed)
+                        else -> item
+                    }
+                }
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/effects/AlertsEffects.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/effects/AlertsEffects.kt
@@ -1,5 +1,5 @@
 package us.docbee.docbeeapp.presentation.alerts.effects
 
 sealed class AlertsEffects {
-
+    data class NavigateEditAlert(val uid: String): AlertsEffects()
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/events/AlertsEvents.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/events/AlertsEvents.kt
@@ -1,9 +1,14 @@
 package us.docbee.docbeeapp.presentation.alerts.events
 
+import us.docbee.docbeeapp.presentation.components.HorizontalSwipeState
+
 sealed class AlertsEvents {
-    data object OnInit: AlertsEvents()
-    data object OnClickAddAlert: AlertsEvents()
-    data object OnClickCloseAddAlert: AlertsEvents()
-    data class OnClickAlert(val uid: String): AlertsEvents()
-    data class OnSaveAlert(val name: String, val message: String): AlertsEvents()
+    data object OnInit : AlertsEvents()
+    data object OnClickAddAlert : AlertsEvents()
+    data object OnClickCloseAddAlert : AlertsEvents()
+    data class OnClickAlert(val uid: String) : AlertsEvents()
+    data class OnSaveAlert(val name: String, val message: String) : AlertsEvents()
+    data class OnDeleteAlert(val uid: String) : AlertsEvents()
+    data class OnEditAlert(val uid: String): AlertsEvents()
+    data class OnSwipeAlertEvent(val uid: String, val swipeState: HorizontalSwipeState) : AlertsEvents()
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/states/UiState.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/states/UiState.kt
@@ -1,9 +1,17 @@
 package us.docbee.docbeeapp.presentation.alerts.states
 
 import us.docbee.docbeeapp.domain.models.alerts.AlertModel
+import us.docbee.docbeeapp.presentation.components.HorizontalSwipeState
 
 data class UiState(
     val isLoading: Boolean = false,
     val isAddingAlert: Boolean = false,
-    val alerts: List<AlertModel> = emptyList()
+    val alerts: List<AlertState> = emptyList()
+)
+
+data class AlertState(
+    val uid: String,
+    val alert: AlertModel,
+    val isSwipeable: Boolean = false,
+    val swipeState: HorizontalSwipeState = HorizontalSwipeState.Closed
 )

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/CardDescriptionItem.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/CardDescriptionItem.kt
@@ -1,32 +1,167 @@
 package us.docbee.docbeeapp.presentation.components
 
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.AnchoredDraggableDefaults
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.anchoredDraggable
+import androidx.compose.foundation.gestures.animateTo
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import docbee.composeapp.generated.resources.Res
+import docbee.composeapp.generated.resources.alerts_item_delete_alert
+import docbee.composeapp.generated.resources.alerts_item_edit_alert
 import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
 import us.docbee.docbeeapp.presentation.theme.Black
 import us.docbee.docbeeapp.presentation.theme.White
+import kotlin.math.roundToInt
 
 @Composable
-fun CardDescriptionItem (
+fun CardDescriptionItem(
     modifier: Modifier = Modifier,
     title: String,
-    description: String? = null,
+    description: String,
+    icon: DrawableResource,
+    onClick: () -> Unit,
+    onDeleteClick: () -> Unit = { },
+    onEditClick: () -> Unit = { },
+    isSwipeable: Boolean = false,
+    swipeState: HorizontalSwipeState = HorizontalSwipeState.Closed,
+    onSwipeChanged: (HorizontalSwipeState) -> Unit = { }
+) {
+
+    if (!isSwipeable) {
+        StaticCardDescriptionItem(
+            modifier = modifier,
+            title = title,
+            description = description,
+            icon = icon,
+            onClick = onClick
+        )
+    } else {
+        SwipeableCardDescriptionItem(
+            modifier = modifier,
+            title = title,
+            description = description,
+            icon = icon,
+            onClick = onClick,
+            onDeleteClick = onDeleteClick,
+            onEditClick = onEditClick,
+            swipeState = swipeState,
+            onSwipeChanged = onSwipeChanged
+        )
+    }
+}
+
+@Composable
+fun SwipeableCardDescriptionItem(
+    modifier: Modifier = Modifier,
+    title: String,
+    description: String,
+    icon: DrawableResource,
+    onClick: () -> Unit,
+    onDeleteClick: () -> Unit,
+    onEditClick: () -> Unit,
+    swipeState: HorizontalSwipeState,
+    onSwipeChanged: (HorizontalSwipeState) -> Unit = { }
+){
+    val density = LocalDensity.current
+    val actionsWidthPx = with(density) { 124.dp.toPx() }
+    val state = remember {
+        AnchoredDraggableState(
+            initialValue = HorizontalSwipeState.Closed,
+            anchors = DraggableAnchors {
+                HorizontalSwipeState.Closed at 0f
+                HorizontalSwipeState.OpenLeft at actionsWidthPx
+                HorizontalSwipeState.OpenRight at -actionsWidthPx
+            }
+        )
+    }
+
+    LaunchedEffect(swipeState) {
+        state.animateTo(swipeState)
+    }
+
+    LaunchedEffect(state.currentValue) {
+        onSwipeChanged(state.currentValue)
+    }
+
+    Box(modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Min)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            BackgroundAlertButton(
+                modifier = Modifier.fillMaxHeight(),
+                text = stringResource(Res.string.alerts_item_delete_alert),
+                onClick = onDeleteClick,
+                color = White
+            )
+            BackgroundAlertButton(
+                modifier = Modifier.fillMaxHeight(),
+                text = stringResource(Res.string.alerts_item_edit_alert),
+                onClick = onEditClick,
+                color = White
+            )
+        }
+        Box(
+            modifier = Modifier.fillMaxWidth()
+                .offset { IntOffset(x = state.requireOffset().roundToInt(), y = 0) }
+                .anchoredDraggable(
+                    state = state,
+                    orientation = Orientation.Horizontal,
+                    flingBehavior = AnchoredDraggableDefaults.flingBehavior(
+                        state = state,
+                        animationSpec = tween(200)
+                    )
+                )
+        ) {
+            StaticCardDescriptionItem(
+                modifier = Modifier,
+                title = title,
+                description = description,
+                icon = icon,
+                onClick = onClick
+            )
+        }
+    }
+}
+
+@Composable
+fun StaticCardDescriptionItem(
+    modifier: Modifier = Modifier,
+    title: String,
+    description: String,
     icon: DrawableResource,
     onClick: () -> Unit
 ) {
@@ -49,14 +184,12 @@ fun CardDescriptionItem (
                 fontWeight = FontWeight.Bold,
                 color = Black
             )
-            if (description != null) {
-                Text(
-                    text = description,
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.Light,
-                    color = Black
-                )
-            }
+            Text(
+                text = description,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Light,
+                color = Black
+            )
         }
         Image(
             modifier = Modifier.size(16.dp),
@@ -65,3 +198,28 @@ fun CardDescriptionItem (
         )
     }
 }
+
+@Composable
+fun BackgroundAlertButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    color: Color,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = modifier.width(120.dp).fillMaxHeight()
+            .background(color = color, shape = RoundedCornerShape(8.dp))
+            .clickable { onClick() }
+    ) {
+        Text(
+            modifier = Modifier.align(Alignment.Center),
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            color = Black,
+            textAlign = TextAlign.Center,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+enum class HorizontalSwipeState { Closed, OpenLeft, OpenRight }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import docbee.composeapp.generated.resources.settings_emergency_notification_des
 import docbee.composeapp.generated.resources.settings_emergency_notification_title
 import docbee.composeapp.generated.resources.settings_location_description
 import docbee.composeapp.generated.resources.settings_location_title
+import docbee.composeapp.generated.resources.settings_logout_description
 import docbee.composeapp.generated.resources.settings_logout_title
 import docbee.composeapp.generated.resources.settings_update_profile_description
 import docbee.composeapp.generated.resources.settings_update_profile_title
@@ -80,6 +81,7 @@ fun SettingsScreen(
         )
         CardDescriptionItem(
             title = stringResource(Res.string.settings_logout_title),
+            description = stringResource(Res.string.settings_logout_description),
             icon = Res.drawable.ic_logout,
             onClick = { viewModel.onEvent(SettingsEvent.OnClickLogout) }
         )

--- a/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.ios.kt
+++ b/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.ios.kt
@@ -3,7 +3,9 @@ package us.docbee.docbeeapp.data.datasources
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.suspendCancellableCoroutine
 import us.docbee.docbeeapp.data.entities.alerts.AlertFetchResponse
+import us.docbee.docbeeapp.data.entities.alerts.AlertSaveResponse
 import us.docbee.docbeeapp.data.entities.alerts.AlertsDeleteResponse
+import us.docbee.docbeeapp.domain.mappers.toAlertDomain
 import us.docbee.docbeeapp.domain.mappers.toMap
 import us.docbee.docbeeapp.domain.mappers.toMutableStringMap
 import us.docbee.docbeeapp.domain.models.alerts.AlertModel
@@ -16,15 +18,21 @@ class IosAlertsRemoteDataSource : AlertsRemoteDataSource {
 
     private val remote = AlertRemoteStorage()
 
-    override suspend fun saveAlert(uid: String, alert: AlertModel) {
-        suspendCancellableCoroutine<Unit> { thread ->
+    override suspend fun saveAlert(uid: String, alert: AlertModel): AlertSaveResponse {
+        return suspendCancellableCoroutine { thread ->
             remote.saveAlertWithCollection(
                 collection = FIRESTORE_COLLECTION_USER,
                 collectionAlert = FIRESTORE_COLLECTION_ALERTS,
                 uid = uid,
                 alert = alert.toMap()
-            ) { error ->
-                thread.resume(Unit, null)
+            ) { alert, error ->
+                val saveResponse = if (alert != null) {
+                    AlertSaveResponse(alert = alert.toMutableStringMap().toAlertDomain())
+                } else {
+                    val errorMessage = error?.userInfo?.get("NSLocalizedDescription") as? String
+                    AlertSaveResponse(errorCode = "UNKNOWN_ERROR", errorMessage = errorMessage)
+                }
+                thread.resume(saveResponse, null)
             }
         }
     }

--- a/iosApp/iosApp/Wrappers/AlertRemoteStorage.swift
+++ b/iosApp/iosApp/Wrappers/AlertRemoteStorage.swift
@@ -18,7 +18,7 @@ public class AlertRemoteStorage: NSObject {
         collectionAlert: String,
         uid: String,
         alert: NSDictionary,
-        completion: @escaping (NSError?) -> Void
+        completion: @escaping (_ result: [String: Any]?, _ error: NSError?) -> Void
     ) {
         let reference = db
             .collection(collection)
@@ -35,7 +35,11 @@ public class AlertRemoteStorage: NSObject {
         data["uid"] = reference.documentID
         
         reference.setData(data) { error in
-            completion(error as NSError?)
+            if (error as NSError? != nil) {
+                completion(nil, error as NSError?)
+            } else {
+                completion(data, nil)
+            }
         }
     }
     

--- a/iosApp/iosApp/Wrappers/Interops/AlertRemoteStorage.h
+++ b/iosApp/iosApp/Wrappers/Interops/AlertRemoteStorage.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
                 collectionAlert:(NSString *)collectionAlert
                               uid:(NSString *)uid
                           alert:(NSDictionary *)alert
-                       completion:(void (^)(NSError * _Nullable error))completion;
+                       completion:(void (^)(NSDictionary * _Nullable result,  NSError * _Nullable error))completion;
 
 - (void)fetchAlertWithCollection:(NSString *)collection
                  collectionAlert:(NSString *)collectionAlert


### PR DESCRIPTION
## 📌 Title  
Add Swipeable Alert Items with Delete and Edit Options  

---

## 📝 Description  
This PR introduces **swipeable alert items** in the UI, allowing users to reveal actions for **delete** and **edit**.  
It also implements the **delete feature** fully integrated with Firestore, enabling real-time removal of alerts from the database.  

---

## 🎨 Visual Evidence

Android

https://github.com/user-attachments/assets/186510bc-1b2e-4a93-81e4-eabb7e568d22

iOS

https://github.com/user-attachments/assets/ca000dc7-218a-4b33-a62d-3379c965c99c

