### PR TITLE
improvement: Refactor firestore communication change maps to classes

### DIFF
--- a/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.android.kt
+++ b/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.android.kt
@@ -1,6 +1,7 @@
 package us.docbee.docbeeapp.data.datasources
 
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.toObject
 import kotlinx.coroutines.tasks.await
 import us.docbee.docbeeapp.data.entities.alerts.AlertFetchResponse
 import us.docbee.docbeeapp.data.entities.alerts.AlertSaveResponse
@@ -41,7 +42,7 @@ class AndroidAlertsRemoteDataSource : AlertsRemoteDataSource {
                 .get()
                 .await()
 
-            AlertFetchResponse(data = query.documents.map { it.data })
+            AlertFetchResponse(data = query.documents.map { it.toObject<AlertModel>() as AlertModel })
 
         } catch (ex: Exception) {
             AlertFetchResponse(errorCode = "UNKNOWN_ERROR", errorMessage = ex.localizedMessage)

--- a/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/data/datasources/ContactRemoteDataSource.android.kt
+++ b/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/data/datasources/ContactRemoteDataSource.android.kt
@@ -1,6 +1,7 @@
 package us.docbee.docbeeapp.data.datasources
 
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.toObject
 import kotlinx.coroutines.tasks.await
 import us.docbee.docbeeapp.data.entities.ContactDeleteResponse
 import us.docbee.docbeeapp.data.entities.ContactFetchResponse
@@ -33,7 +34,7 @@ class AndroidContactRemoteDataSource : ContactRemoteDataSource {
                 .get()
                 .await()
 
-            ContactFetchResponse(data = query.documents.map { it.data })
+            ContactFetchResponse(data = query.documents.map { it.toObject<ContactModel>() as ContactModel })
 
         } catch (ex: Exception) {
             ContactFetchResponse(errorCode = "UNKNOWN_ERROR", errorMessage = ex.localizedMessage)

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/entities/ContactFetchResponse.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/entities/ContactFetchResponse.kt
@@ -1,7 +1,9 @@
 package us.docbee.docbeeapp.data.entities
 
+import us.docbee.docbeeapp.domain.models.directory.ContactModel
+
 data class ContactFetchResponse(
-    val data: List<MutableMap<String, Any>?>? = null,
+    val data: List<ContactModel>? = null,
     val errorCode: String? = null,
     val errorMessage: String? = null
 )

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/entities/alerts/AlertFetchResponse.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/entities/alerts/AlertFetchResponse.kt
@@ -1,7 +1,9 @@
 package us.docbee.docbeeapp.data.entities.alerts
 
+import us.docbee.docbeeapp.domain.models.alerts.AlertModel
+
 data class AlertFetchResponse(
-    val data: List<MutableMap<String, Any>?>? = null,
+    val data: List<AlertModel>? = null,
     val errorCode: String? = null,
     val errorMessage: String? = null
 )

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/repositories/AlertsDataRepository.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/repositories/AlertsDataRepository.kt
@@ -2,7 +2,6 @@ package us.docbee.docbeeapp.data.repositories
 
 import us.docbee.docbeeapp.data.datasources.AlertsRemoteDataSource
 import us.docbee.docbeeapp.domain.managers.AlertsStringsManager
-import us.docbee.docbeeapp.domain.mappers.toAlertDomain
 import us.docbee.docbeeapp.domain.models.alerts.AddAlertResult
 import us.docbee.docbeeapp.domain.models.alerts.AlertModel
 import us.docbee.docbeeapp.domain.models.alerts.DeleteAlertResult
@@ -18,7 +17,7 @@ class AlertsDataRepository(
         var alertList = mutableListOf<AlertModel>().apply { addAll(defaultList()) }
 
         val response = alertDataSource.fetchAlert(uid)
-        response.data?.mapNotNull { it?.toAlertDomain() }?.let {
+        response.data?.mapNotNull { it }?.let {
             alertList.addAll(it)
         }
 

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/repositories/ContactDataRepository.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/repositories/ContactDataRepository.kt
@@ -1,7 +1,6 @@
 package us.docbee.docbeeapp.data.repositories
 
 import us.docbee.docbeeapp.data.datasources.ContactRemoteDataSource
-import us.docbee.docbeeapp.domain.mappers.toContactDomain
 import us.docbee.docbeeapp.domain.models.directory.ContactModel
 import us.docbee.docbeeapp.domain.models.directory.ContactResult
 import us.docbee.docbeeapp.domain.models.directory.DeleteContactResult
@@ -18,7 +17,7 @@ class ContactDataRepository(val contactDataSource: ContactRemoteDataSource): Con
         return when {
             response.errorCode != null -> ContactResult.Error
             response.data.isNullOrEmpty() -> ContactResult.Empty
-            else -> ContactResult.Success(list = response.data.mapNotNull { it?.toContactDomain() })
+            else -> ContactResult.Success(list = response.data.map { it })
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/mappers/AlertsMapper.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/mappers/AlertsMapper.kt
@@ -10,13 +10,6 @@ fun AlertModel.toMap(): Map<Any?, *> = mapOf(
     "uid" to uid
 )
 
-fun MutableMap<String, Any>.toAlertDomain() = AlertModel(
-    uid = this["uid"] as String,
-    name = this["name"] as String,
-    message = this["message"] as String,
-    icon = this["icon"] as String
-)
-
 fun AlertParams.toAlertModel(): AlertModel = AlertModel(
     name = name,
     message = message,

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/mappers/ContactsMapper.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/mappers/ContactsMapper.kt
@@ -13,23 +13,6 @@ fun ContactModel.toMap(): Map<Any?, *> = mapOf(
     "uid" to uid
 )
 
-fun Any?.toMutableStringMap(): MutableMap<String, Any> {
-    val dictionary = this as? Map<*, *> ?: return mutableMapOf()
-    return dictionary.entries.mapNotNull { (key, value) ->
-        (key as? String)?.let { it to (value ?: "") }
-    }.toMap(mutableMapOf())
-}
-
-fun MutableMap<String, Any>.toContactDomain() = ContactModel(
-    uid = this["uid"] as String,
-    firstName = this["firstName"] as String,
-    lastName = this["lastName"] as String,
-    email = this["email"] as String,
-    phoneNumber = this["phoneNumber"] as String,
-    gender = this["gender"] as String,
-    address = this["address"] as String
-)
-
 fun ContactParams.toContactModel(): ContactModel = ContactModel(
     firstName = name,
     lastName = lastName,

--- a/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.ios.kt
+++ b/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.ios.kt
@@ -5,9 +5,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import us.docbee.docbeeapp.data.entities.alerts.AlertFetchResponse
 import us.docbee.docbeeapp.data.entities.alerts.AlertSaveResponse
 import us.docbee.docbeeapp.data.entities.alerts.AlertsDeleteResponse
-import us.docbee.docbeeapp.domain.mappers.toAlertDomain
 import us.docbee.docbeeapp.domain.mappers.toMap
-import us.docbee.docbeeapp.domain.mappers.toMutableStringMap
 import us.docbee.docbeeapp.domain.models.alerts.AlertModel
 import us.docbee.docbeeapp.utils.FIRESTORE_COLLECTION_ALERTS
 import us.docbee.docbeeapp.utils.FIRESTORE_COLLECTION_USER
@@ -18,6 +16,7 @@ class IosAlertsRemoteDataSource : AlertsRemoteDataSource {
 
     private val remote = AlertRemoteStorage()
 
+    @Suppress("CAST_NEVER_SUCCEEDS")
     override suspend fun saveAlert(uid: String, alert: AlertModel): AlertSaveResponse {
         return suspendCancellableCoroutine { thread ->
             remote.saveAlertWithCollection(
@@ -27,7 +26,7 @@ class IosAlertsRemoteDataSource : AlertsRemoteDataSource {
                 alert = alert.toMap()
             ) { alert, error ->
                 val saveResponse = if (alert != null) {
-                    AlertSaveResponse(alert = alert.toMutableStringMap().toAlertDomain())
+                    AlertSaveResponse(alert = alert as? AlertModel)
                 } else {
                     val errorMessage = error?.userInfo?.get("NSLocalizedDescription") as? String
                     AlertSaveResponse(errorCode = "UNKNOWN_ERROR", errorMessage = errorMessage)
@@ -45,7 +44,7 @@ class IosAlertsRemoteDataSource : AlertsRemoteDataSource {
                 uid = uid
             ) { alerts, error ->
                 val alertResponse = if (alerts != null) {
-                    AlertFetchResponse(data = alerts.map { it.toMutableStringMap() })
+                    AlertFetchResponse(data = alerts.map { it as AlertModel })
                 } else {
                     val errorCode = error?.userInfo?.get("FIRAuthErrorUserInfoNameKey") as? String
                     val errorMessage = error?.userInfo?.get("NSLocalizedDescription") as? String

--- a/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/data/datasources/ContactRemoteDataSource.ios.kt
+++ b/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/data/datasources/ContactRemoteDataSource.ios.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import us.docbee.docbeeapp.data.entities.ContactDeleteResponse
 import us.docbee.docbeeapp.data.entities.ContactFetchResponse
 import us.docbee.docbeeapp.domain.mappers.toMap
-import us.docbee.docbeeapp.domain.mappers.toMutableStringMap
 import us.docbee.docbeeapp.domain.models.directory.ContactModel
 import us.docbee.docbeeapp.utils.FIRESTORE_COLLECTION_CONTACTS
 import us.docbee.docbeeapp.utils.FIRESTORE_COLLECTION_USER
@@ -37,7 +36,7 @@ class IosContactRemoteDataSource: ContactRemoteDataSource {
                 uid = uid
             ) { contacts, error ->
                 val contactResponse = if (contacts != null) {
-                    ContactFetchResponse(data = contacts.map { it.toMutableStringMap() })
+                    ContactFetchResponse(data = contacts.map { it as ContactModel })
                 } else {
                     val errorCode = error?.userInfo?.get("FIRAuthErrorUserInfoNameKey") as? String
                     val errorMessage = error?.userInfo?.get("NSLocalizedDescription") as? String

--- a/iosApp/iosApp/Wrappers/AlertRemoteStorage.swift
+++ b/iosApp/iosApp/Wrappers/AlertRemoteStorage.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import FirebaseFirestore
+import ComposeApp
 
 @objc(AlertRemoteStorage)
 public class AlertRemoteStorage: NSObject {
@@ -18,7 +19,7 @@ public class AlertRemoteStorage: NSObject {
         collectionAlert: String,
         uid: String,
         alert: NSDictionary,
-        completion: @escaping (_ result: [String: Any]?, _ error: NSError?) -> Void
+        completion: @escaping (_ result: AlertModel?, _ error: NSError?) -> Void
     ) {
         let reference = db
             .collection(collection)
@@ -38,7 +39,12 @@ public class AlertRemoteStorage: NSObject {
             if (error as NSError? != nil) {
                 completion(nil, error as NSError?)
             } else {
-                completion(data, nil)
+                do {
+                    let alertDocument = try self.decode(dictionary: data, into: AlertDocument.self)
+                    completion(alertDocument.toObject(), nil)
+                } catch {
+                    completion(nil, error as NSError?)
+                }
             }
         }
     }
@@ -47,7 +53,7 @@ public class AlertRemoteStorage: NSObject {
         collection: String,
         collectionAlert: String,
         uid: String,
-        completion: @escaping (_ result: [[String: Any]]?, _ error: NSError?) -> Void
+        completion: @escaping (_ result: [AlertModel]?, _ error: NSError?) -> Void
     ) {
         Task {
             do {
@@ -56,7 +62,16 @@ public class AlertRemoteStorage: NSObject {
                     .collection(collectionAlert)
                     .getDocuments()
                 
-                completion(querySnapshot.documents.map { $0.data() }, nil)
+                var alertModel = [AlertModel]()
+                for document in querySnapshot.documents {
+                    do {
+                        let swiftDocument = try document.data(as: AlertDocument.self)
+                        alertModel.append(swiftDocument.toObject())
+                    } catch let decodingError as NSError {
+                        completion(nil, decodingError)
+                    }
+                }
+                completion(alertModel, nil)
             } catch {
                 completion(nil, error as NSError?)
             }
@@ -84,4 +99,34 @@ public class AlertRemoteStorage: NSObject {
         }
     }
     
+    func decode<T: Decodable>(dictionary: [String: Any], into type: T.Type) throws -> T {
+        let jsonData = try JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let decoder = JSONDecoder()
+        return try decoder.decode(T.self, from: jsonData)
+    }
+}
+
+struct AlertDocument: Codable {
+    let name: String
+    let message: String
+    let icon: String
+    let uid: String
+   
+    enum CodingKeys: String, CodingKey {
+        case name
+        case message
+        case icon
+        case uid
+    }
+}
+
+extension AlertDocument {
+    func toObject() -> AlertModel {
+        return AlertModel(
+            uid: self.uid,
+            name: self.name,
+            message: self.message,
+            icon: self.icon
+        )
+    }
 }

--- a/iosApp/iosApp/Wrappers/ContactRemoteStorage.swift
+++ b/iosApp/iosApp/Wrappers/ContactRemoteStorage.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import FirebaseFirestore
+import ComposeApp
 
 @objc(ContactRemoteStorage)
 public class ContactRemoteStorage: NSObject {
@@ -44,7 +45,7 @@ public class ContactRemoteStorage: NSObject {
         collection: String,
         collectionContact: String,
         uid: String,
-        completion: @escaping (_ result: [[String: Any]]?, _ error: NSError?) -> Void
+        completion: @escaping (_ result: [ContactModel]?, _ error: NSError?) -> Void
     ) {
         Task {
             do {
@@ -52,8 +53,17 @@ public class ContactRemoteStorage: NSObject {
                     .document(uid)
                     .collection(collectionContact)
                     .getDocuments()
+                var contactModel = [ContactModel]()
+                for document in querySnapshot.documents {
+                    do {
+                        let swiftDocument = try document.data(as: ContactDocument.self)
+                        contactModel.append(swiftDocument.toObject())
+                    } catch let decodingError as NSError {
+                        completion(nil, decodingError)
+                    }
+                }
                 
-                completion(querySnapshot.documents.map { $0.data() }, nil)
+                completion(contactModel, nil)
             } catch {
                 completion(nil, error as NSError?)
             }
@@ -79,5 +89,42 @@ public class ContactRemoteStorage: NSObject {
                 completion(false, error as NSError?)
             }
         }
+    }
+}
+
+struct ContactDocument: Codable {
+    let firstName: String
+    let lastName: String
+    let email: String
+    let phoneNumber: String
+    let dateOfBirth: String
+    let address: String
+    let gender: String
+    let uid: String
+    
+    enum CodingKeys: String, CodingKey {
+        case firstName
+        case lastName
+        case email
+        case phoneNumber
+        case dateOfBirth
+        case address
+        case gender
+        case uid
+    }
+}
+
+extension ContactDocument {
+    func toObject() -> ContactModel {
+        return ContactModel(
+            uid: self.uid,
+            firstName: self.firstName,
+            lastName: self.lastName,
+            email: self.email,
+            phoneNumber: self.phoneNumber,
+            dateOfBirth: self.dateOfBirth,
+            address: self.address,
+            gender: self.gender
+        )
     }
 }

--- a/iosApp/iosApp/Wrappers/Interops/AlertRemoteStorage.h
+++ b/iosApp/iosApp/Wrappers/Interops/AlertRemoteStorage.h
@@ -15,12 +15,12 @@ NS_ASSUME_NONNULL_BEGIN
                 collectionAlert:(NSString *)collectionAlert
                               uid:(NSString *)uid
                           alert:(NSDictionary *)alert
-                       completion:(void (^)(NSDictionary * _Nullable result,  NSError * _Nullable error))completion;
+                       completion:(void (^)(NSObject * _Nullable result,  NSError * _Nullable error))completion;
 
 - (void)fetchAlertWithCollection:(NSString *)collection
                  collectionAlert:(NSString *)collectionAlert
                                uid:(NSString *)uid
-                        completion:(void (^)(NSArray<NSDictionary *> * _Nullable result, NSError * _Nullable error))completion;
+                        completion:(void (^)(NSArray<NSObject *> * _Nullable result, NSError * _Nullable error))completion;
 
 - (void)deleteAlertWithCollection:(NSString *)collection
                   collectionAlert:(NSString *)collectionAlert

--- a/iosApp/iosApp/Wrappers/Interops/ContactRemoteStorage.h
+++ b/iosApp/iosApp/Wrappers/Interops/ContactRemoteStorage.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)fetchContactWithCollection:(NSString *)collection
                  collectionContact:(NSString *)collectionContact
                                uid:(NSString *)uid
-                        completion:(void (^)(NSArray<NSDictionary *> * _Nullable result, NSError * _Nullable error))completion;
+                        completion:(void (^)(NSArray<NSObject *> * _Nullable result, NSError * _Nullable error))completion;
 
 - (void)deleteContactWithCollection:(NSString *)collection
                  collectionContact:(NSString *)collectionContact


### PR DESCRIPTION
## 📌 Title  
Refactor Firestore Communication to Use Classes Instead of Maps  

---

## 📝 Description  
This PR refactors the Firestore integration to replace the use of **generic maps** with **typed classes**, improving type safety, readability, and maintainability of the codebase.  
The change ensures more consistent data handling across the app and reduces potential runtime errors.  
