### PR TITLE
feature: Implement Alert Editing Functionality Stored in Firestore

### DIFF
--- a/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.android.kt
+++ b/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.android.kt
@@ -62,6 +62,24 @@ class AndroidAlertsRemoteDataSource : AlertsRemoteDataSource {
             AlertsDeleteResponse(errorCode = "UNKNOWN_ERROR", errorMessage = ex.localizedMessage)
         }
     }
+
+    override suspend fun editAlert(uid: String, alert: AlertModel): AlertSaveResponse {
+        return try {
+            db.collection(FIRESTORE_COLLECTION_USER)
+                .document(uid)
+                .collection(FIRESTORE_COLLECTION_ALERTS)
+                .document(alert.uid)
+                .update(
+                    "name", alert.name,
+                    "message", alert.message
+                )
+                .await()
+            AlertSaveResponse(alert = alert)
+        } catch (ex: Exception) {
+            AlertSaveResponse(errorCode = "UNKNOWN_ERROR", errorMessage = ex.localizedMessage)
+        }
+
+    }
 }
 
 actual fun getAlertsDataSource(): AlertsRemoteDataSource = AndroidAlertsRemoteDataSource()

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.kt
@@ -9,6 +9,7 @@ interface AlertsRemoteDataSource {
     suspend fun saveAlert(uid: String, alert: AlertModel): AlertSaveResponse
     suspend fun fetchAlert(uid: String): AlertFetchResponse
     suspend fun deleteAlert(uid: String, alertUid: String): AlertsDeleteResponse
+    suspend fun editAlert(uid: String, alert: AlertModel): AlertSaveResponse
 }
 
 expect fun getAlertsDataSource(): AlertsRemoteDataSource

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/repositories/AlertsDataRepository.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/repositories/AlertsDataRepository.kt
@@ -43,6 +43,17 @@ class AlertsDataRepository(
         }
     }
 
+    override suspend fun modifyAlert(
+        uid: String,
+        alert: AlertModel
+    ): AddAlertResult {
+        val response = alertDataSource.editAlert(uid, alert)
+        return when {
+            response.alert != null -> AddAlertResult.Success(response.alert)
+            else -> AddAlertResult.Error
+        }
+    }
+
     private suspend fun defaultList(): List<AlertModel> {
         return listOf(
             AlertModel(

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
@@ -49,6 +49,7 @@ import us.docbee.docbeeapp.domain.usecases.NotifyEmergencyUseCase
 import us.docbee.docbeeapp.domain.usecases.SaveUserContactUseCase
 import us.docbee.docbeeapp.domain.usecases.SendEmergencyUseCase
 import us.docbee.docbeeapp.domain.usecases.alerts.DeleteAlertsUseCase
+import us.docbee.docbeeapp.domain.usecases.alerts.ModifyAlertsUseCase
 import us.docbee.docbeeapp.domain.usecases.alerts.SaveAlertsUseCase
 import us.docbee.docbeeapp.domain.usecases.directory.DeleteUserContactUseCase
 import us.docbee.docbeeapp.presentation.alerts.AlertsViewModel
@@ -103,6 +104,7 @@ val usesCasesModule = module {
     factory { GetAlertsUseCase(get(), get()) }
     factory { SaveAlertsUseCase(get(), get()) }
     factory { DeleteAlertsUseCase(get(), get()) }
+    factory { ModifyAlertsUseCase(get(), get()) }
 }
 
 

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/mappers/AlertsMapper.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/mappers/AlertsMapper.kt
@@ -1,6 +1,7 @@
 package us.docbee.docbeeapp.domain.mappers
 
 import us.docbee.docbeeapp.domain.models.alerts.AlertModel
+import us.docbee.docbeeapp.domain.models.alerts.AlertModifyParams
 import us.docbee.docbeeapp.domain.models.alerts.AlertParams
 
 fun AlertModel.toMap(): Map<Any?, *> = mapOf(
@@ -11,6 +12,13 @@ fun AlertModel.toMap(): Map<Any?, *> = mapOf(
 )
 
 fun AlertParams.toAlertModel(): AlertModel = AlertModel(
+    name = name,
+    message = message,
+    icon = icon
+)
+
+fun AlertModifyParams.toAlertModel(): AlertModel = AlertModel(
+    uid = uid,
     name = name,
     message = message,
     icon = icon

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/alerts/AlertParams.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/alerts/AlertParams.kt
@@ -5,3 +5,10 @@ data class AlertParams(
     val message: String,
     val icon: String
 )
+
+data class AlertModifyParams(
+    val uid: String,
+    val name: String,
+    val message: String,
+    val icon: String
+)

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/repositories/AlertsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/repositories/AlertsRepository.kt
@@ -9,4 +9,5 @@ interface AlertsRepository {
     suspend fun fetchAlerts(uid: String): FetchAlertsResult
     suspend fun saveAlerts(uid: String, alert: AlertModel): AddAlertResult
     suspend fun deleteAlert(uid: String, alertUid: String): DeleteAlertResult
+    suspend fun modifyAlert(uid: String, alert: AlertModel): AddAlertResult
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/usecases/alerts/ModifyAlertsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/usecases/alerts/ModifyAlertsUseCase.kt
@@ -1,0 +1,22 @@
+package us.docbee.docbeeapp.domain.usecases.alerts
+
+import us.docbee.docbeeapp.domain.mappers.toAlertModel
+import us.docbee.docbeeapp.domain.models.alerts.AddAlertResult
+import us.docbee.docbeeapp.domain.models.alerts.AlertModifyParams
+import us.docbee.docbeeapp.domain.models.directory.UserUidResult
+import us.docbee.docbeeapp.domain.repositories.AlertsRepository
+import us.docbee.docbeeapp.domain.repositories.UserRepository
+
+class ModifyAlertsUseCase(
+    private val alertsRepository: AlertsRepository,
+    private val userRepository: UserRepository
+) {
+    suspend fun modifyAlert(alert: AlertModifyParams): AddAlertResult {
+        val userResponse = userRepository.fetchUserId()
+        if (userResponse !is UserUidResult.Success) {
+            return AddAlertResult.Unauthorized
+        }
+
+        return alertsRepository.modifyAlert(userResponse.uid, alert.toAlertModel())
+    }
+}

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/AlertsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/AlertsScreen.kt
@@ -66,8 +66,11 @@ fun AlertsScreen(
     LaunchedEffect(Unit) {
         viewModel.effect.collectLatest { effect ->
             when (effect) {
-                is AlertsEffects.NavigateEditAlert -> Unit // TODO: Navigate to Edit Alert
-                is AlertsEffects.NavigateSendAlert -> parentNavController.navigate(AlertDetailRoute(effect.uid))
+                is AlertsEffects.NavigateSendAlert -> parentNavController.navigate(
+                    AlertDetailRoute(
+                        effect.uid
+                    )
+                )
             }
         }
     }
@@ -101,12 +104,24 @@ fun AlertsScreen(
             onClick = { viewModel.onEvent(AlertsEvents.OnClickAddAlert) }
         )
         AddAlertBottomSheet(
-            isSheetVisible = uiState.isAddingAlert,
+            isSheetVisible = uiState.isAddingAlert || uiState.isEditingAlert,
             bottomSheetState = bottomSheetState,
             onDismissRequest = { viewModel.onEvent(AlertsEvents.OnClickCloseAddAlert) },
             onClickSave = { name, message ->
-                viewModel.onEvent(AlertsEvents.OnSaveAlert(name, message))
-            }
+                if (!uiState.isEditingAlert) {
+                    viewModel.onEvent(AlertsEvents.OnSaveAlert(name, message))
+                } else {
+                    viewModel.onEvent(
+                        AlertsEvents.OnSaveEditedAlert(
+                            uid = uiState.editingAlert?.uid ?: "",
+                            name = name,
+                            message = message
+                        )
+                    )
+                }
+            },
+            defaultName = uiState.editingAlert?.name ?: "",
+            defaultDescription = uiState.editingAlert?.message ?: "",
         )
     }
 }
@@ -117,10 +132,12 @@ fun AddAlertBottomSheet(
     isSheetVisible: Boolean,
     bottomSheetState: SheetState,
     onDismissRequest: () -> Unit,
-    onClickSave: (String, String) -> Unit
+    onClickSave: (String, String) -> Unit,
+    defaultName: String = "",
+    defaultDescription: String = "",
 ) {
-    var alertName by remember(isSheetVisible) { mutableStateOf("") }
-    var alertMessage by remember(isSheetVisible) { mutableStateOf("") }
+    var alertName by remember(isSheetVisible) { mutableStateOf(defaultName) }
+    var alertMessage by remember(isSheetVisible) { mutableStateOf(defaultDescription) }
 
     if (isSheetVisible) {
         ModalBottomSheet(

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/AlertsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/AlertsViewModel.kt
@@ -3,11 +3,13 @@ package us.docbee.docbeeapp.presentation.alerts
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 import us.docbee.docbeeapp.domain.models.alerts.AddAlertResult
+import us.docbee.docbeeapp.domain.models.alerts.AlertModifyParams
 import us.docbee.docbeeapp.domain.models.alerts.AlertParams
 import us.docbee.docbeeapp.domain.models.alerts.DeleteAlertResult
 import us.docbee.docbeeapp.domain.models.alerts.FetchAlertsResult
 import us.docbee.docbeeapp.domain.usecases.alerts.DeleteAlertsUseCase
 import us.docbee.docbeeapp.domain.usecases.alerts.GetAlertsUseCase
+import us.docbee.docbeeapp.domain.usecases.alerts.ModifyAlertsUseCase
 import us.docbee.docbeeapp.domain.usecases.alerts.SaveAlertsUseCase
 import us.docbee.docbeeapp.presentation.alerts.effects.AlertsEffects
 import us.docbee.docbeeapp.presentation.alerts.events.AlertsEvents
@@ -19,7 +21,8 @@ import us.docbee.docbeeapp.presentation.core.BaseViewModel
 class AlertsViewModel(
     private val getAlertsUseCase: GetAlertsUseCase,
     private val saveAlertsUseCase: SaveAlertsUseCase,
-    private val deleteAlertsUseCase: DeleteAlertsUseCase
+    private val deleteAlertsUseCase: DeleteAlertsUseCase,
+    private val modifyAlertsUseCase: ModifyAlertsUseCase
 ) : BaseViewModel<UiState, AlertsEvents, AlertsEffects>(UiState()) {
 
     init {
@@ -36,6 +39,7 @@ class AlertsViewModel(
             is AlertsEvents.OnDeleteAlert -> onDeleteAlertClicked(event.uid)
             is AlertsEvents.OnEditAlert -> onEditAlertClicked(event.uid)
             is AlertsEvents.OnSwipeAlertEvent -> onSwipeAlertEvent(event.uid, event.swipeState)
+            is AlertsEvents.OnSaveEditedAlert -> onSaveEditedAlert(event.uid, event.name, event.message)
         }
     }
 
@@ -66,7 +70,7 @@ class AlertsViewModel(
     }
 
     private fun onClickCloseAddAlert() {
-        updateState { copy(isAddingAlert = false) }
+        updateState { copy(isAddingAlert = false, isEditingAlert = false, editingAlert = null) }
     }
 
     private fun onAlertClicked(uid: String) {
@@ -117,7 +121,19 @@ class AlertsViewModel(
     }
 
     private fun onEditAlertClicked(uid: String) {
-        emitEffect(AlertsEffects.NavigateEditAlert(uid))
+        updateState {
+            copy(
+                isEditingAlert = true,
+                editingAlert = alerts.find { it.uid == uid }?.alert,
+                alerts = alerts.map { item ->
+                    if (item.uid == uid) {
+                        item.copy(swipeState = HorizontalSwipeState.Closed)
+                    } else {
+                        item
+                    }
+                }
+            )
+        }
     }
 
     private fun onSwipeAlertEvent(uid: String, state: HorizontalSwipeState) {
@@ -132,6 +148,31 @@ class AlertsViewModel(
                     }
                 }
             )
+        }
+    }
+
+    private fun onSaveEditedAlert(uid: String, name: String, message: String) {
+        viewModelScope.launch {
+            val params = AlertModifyParams(uid = uid, name = name, message = message, icon = "DEFAULT")
+            when (val alertsResult = modifyAlertsUseCase.modifyAlert(params)) {
+                is AddAlertResult.Success -> {
+                    updateState {
+                        copy(
+                            isEditingAlert = false,
+                            editingAlert = null,
+                            alerts = alerts.map { item ->
+                                if (item.uid == uid) {
+                                    item.copy(alert = alertsResult.alert)
+                                } else {
+                                    item
+                                }
+                            }
+                        )
+                    }
+                }
+
+                is AddAlertResult.Error, is AddAlertResult.Unauthorized -> Unit
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/effects/AlertsEffects.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/effects/AlertsEffects.kt
@@ -1,6 +1,5 @@
 package us.docbee.docbeeapp.presentation.alerts.effects
 
 sealed class AlertsEffects {
-    data class NavigateEditAlert(val uid: String): AlertsEffects()
     data class NavigateSendAlert(val uid: String): AlertsEffects()
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/events/AlertsEvents.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/events/AlertsEvents.kt
@@ -11,4 +11,5 @@ sealed class AlertsEvents {
     data class OnDeleteAlert(val uid: String) : AlertsEvents()
     data class OnEditAlert(val uid: String): AlertsEvents()
     data class OnSwipeAlertEvent(val uid: String, val swipeState: HorizontalSwipeState) : AlertsEvents()
+    data class OnSaveEditedAlert(val uid: String, val name: String, val message: String): AlertsEvents()
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/states/UiState.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/alerts/states/UiState.kt
@@ -6,6 +6,8 @@ import us.docbee.docbeeapp.presentation.components.HorizontalSwipeState
 data class UiState(
     val isLoading: Boolean = false,
     val isAddingAlert: Boolean = false,
+    val isEditingAlert: Boolean = false,
+    val editingAlert: AlertModel? = null,
     val alerts: List<AlertState> = emptyList()
 )
 

--- a/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.ios.kt
+++ b/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/data/datasources/AlertsRemoteDataSource.ios.kt
@@ -73,6 +73,29 @@ class IosAlertsRemoteDataSource : AlertsRemoteDataSource {
             }
         }
     }
+
+    @Suppress("CAST_NEVER_SUCCEEDS")
+    override suspend fun editAlert(
+        uid: String,
+        alert: AlertModel
+    ): AlertSaveResponse {
+        return suspendCancellableCoroutine { thread ->
+            remote.modifyAlertWithCollection(
+                collection = FIRESTORE_COLLECTION_USER,
+                collectionAlert = FIRESTORE_COLLECTION_ALERTS,
+                uid = uid,
+                alert = alert.toMap()
+            ) { alert, error ->
+                val saveResponse = if (alert != null) {
+                    AlertSaveResponse(alert = alert as? AlertModel)
+                } else {
+                    val errorMessage = error?.userInfo?.get("NSLocalizedDescription") as? String
+                    AlertSaveResponse(errorCode = "UNKNOWN_ERROR", errorMessage = errorMessage)
+                }
+                thread.resume(saveResponse, null)
+            }
+        }
+    }
 }
 
 actual fun getAlertsDataSource(): AlertsRemoteDataSource = IosAlertsRemoteDataSource()

--- a/iosApp/iosApp/Wrappers/AlertRemoteStorage.swift
+++ b/iosApp/iosApp/Wrappers/AlertRemoteStorage.swift
@@ -99,6 +99,40 @@ public class AlertRemoteStorage: NSObject {
         }
     }
     
+    @objc public func modifyAlert(
+        collection: String,
+        collectionAlert: String,
+        uid: String,
+        alert: NSDictionary,
+        completion: @escaping (_ result: AlertModel?, _ error: NSError?) -> Void
+    ) {
+        Task {
+            var data: [String: Any] = [:]
+            for (key, value) in alert {
+                if let keyString = key as? String {
+                    data[keyString] = value
+                }
+            }
+            
+            let reference = db
+                .collection(collection)
+                .document(uid)
+                .collection(collectionAlert)
+                .document(data["uid"] as? String ?? "")
+            
+            do {
+                try await reference.updateData([
+                    "name": (data["name"] ?? "") as Any,
+                    "message": (data["message"] ?? "") as Any
+                ])
+                let alertDocument = try self.decode(dictionary: data, into: AlertDocument.self)
+                completion(alertDocument.toObject(), nil)
+            } catch {
+                completion(nil, error as NSError?)
+            }
+        }
+    }
+    
     func decode<T: Decodable>(dictionary: [String: Any], into type: T.Type) throws -> T {
         let jsonData = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()

--- a/iosApp/iosApp/Wrappers/Interops/AlertRemoteStorage.h
+++ b/iosApp/iosApp/Wrappers/Interops/AlertRemoteStorage.h
@@ -28,6 +28,12 @@ NS_ASSUME_NONNULL_BEGIN
                          alertUid:(NSString *)alertUid
                          completion:(void (^)(BOOL success, NSError * _Nullable error))completion;
 
+- (void)modifyAlertWithCollection:(NSString *)collection
+                collectionAlert:(NSString *)collectionAlert
+                              uid:(NSString *)uid
+                          alert:(NSDictionary *)alert
+                       completion:(void (^)(NSObject * _Nullable result,  NSError * _Nullable error))completion;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## 📌 Title  
Implement Alert Editing Functionality Stored in Firestore  

---

## 📝 Description  
This PR adds full **edit functionality for alerts**, allowing users to modify existing alert information.  
All edits are now persisted in **Firestore**, ensuring real-time synchronization and consistent data across devices.  

---

## 🎨 Visual Evidence


https://github.com/user-attachments/assets/623a5894-3c74-4509-9f07-05b3be1c1454


https://github.com/user-attachments/assets/f2262ecc-b0be-4df5-b16a-3d29d088a2cf
