### PR TITLE
fix: Solve contacts model mapping to avoid crash when is read

### DIFF
--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/mappers/ContactsMapper.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/mappers/ContactsMapper.kt
@@ -8,6 +8,7 @@ fun ContactModel.toMap(): Map<Any?, *> = mapOf(
     "lastName" to lastName,
     "email" to email,
     "phoneNumber" to phoneNumber,
+    "dateOfBirth" to dateOfBirth,
     "gender" to gender,
     "address" to address,
     "uid" to uid

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,5 +11,4 @@ org.gradle.caching=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 
-kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.enableCInteropCommonization.nowarn=true #this part is optional

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		B99700CA2DC9B8D800C7335B /* Exceptions for "iosApp" folder in "iosApp" target */ = {
+		B99700CA2DC9B8D800C7335B /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -31,7 +31,7 @@
 		B9DA97B32DC1472C00A4DA20 /* iosApp */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				B99700CA2DC9B8D800C7335B /* Exceptions for "iosApp" folder in "iosApp" target */,
+				B99700CA2DC9B8D800C7335B /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -319,7 +319,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = "${TEAM_ID}";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
## 📌 Title  
Fix Crash When Creating Contact Due to Missing Birth Date Field  

---

## 📝 Description  
This PR fixes a bug where newly created contacts were saved to Firestore **without the `dateOfBirth` field**.  
When loading contacts, this caused a crash because the Codable model defines this property as **non-null**, resulting in a decoding failure.  

---

## 🔄 Changes  
- Fixed contact creation flow to include the **dateOfBirth** key-value when saving to Firestore.
