### PR TITLE
[BOC] Add action when Ime Action is clicked on InputFieldText

### DIFF
--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/inputs/InputFieldText.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/inputs/InputFieldText.kt
@@ -45,7 +45,8 @@ fun InputFieldText(
     isError: Boolean = false,
     errorLabel: String = "",
     onValueChange: (String) -> Unit,
-    onTrailingIconClick: () -> Unit = { }
+    onTrailingIconClick: () -> Unit = { },
+    onImeActionClick: (() -> Unit)? = null,
 ) {
     val focusManager = LocalFocusManager.current
 
@@ -80,7 +81,13 @@ fun InputFieldText(
                 imeAction = imeAction
             ),
             keyboardActions = KeyboardActions(
-                onNext = { focusManager.moveFocus(focusDirection) }
+                onNext = { focusManager.moveFocus(focusDirection) },
+                onDone = onImeActionClick?.let {
+                    {
+                        focusManager.clearFocus()
+                        it.invoke()
+                    }
+                }
             ),
             trailingIcon = {
                 if (trailingIcon != null) {

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/inputs/InputPasswordFieldText.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/components/inputs/InputPasswordFieldText.kt
@@ -26,7 +26,8 @@ fun InputPasswordFieldText(
     imeAction: ImeAction = ImeAction.Next,
     focusDirection: FocusDirection = FocusDirection.Down,
     isError: Boolean = false,
-    errorLabel: String = ""
+    errorLabel: String = "",
+    onImeActionClick: (() -> Unit)? = null,
 ) {
     var isPasswordVisible by remember { mutableStateOf(false) }
     InputFieldText(
@@ -50,6 +51,7 @@ fun InputPasswordFieldText(
         keyboardCapitalization = KeyboardCapitalization.None,
         keyboardType = KeyboardType.Password,
         isError = isError,
-        errorLabel = errorLabel
+        errorLabel = errorLabel,
+        onImeActionClick = onImeActionClick,
     )
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/LoginScreen.kt
@@ -120,7 +120,8 @@ fun LoginContainer(
             onValueChange = onChangePassword,
             imeAction = ImeAction.Done,
             isError = isPasswordError,
-            errorLabel = stringResource(Res.string.login_form_password_field_error)
+            errorLabel = stringResource(Res.string.login_form_password_field_error),
+            onImeActionClick = onLoginClick,
         )
         Spacer(modifier = Modifier.height(16.dp))
         Row(

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/SignupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/SignupScreen.kt
@@ -137,7 +137,7 @@ fun SignupContainer(
         InputFieldText(
             inputLabel = stringResource(Res.string.signup_form_name_field),
             keyboardCapitalization = KeyboardCapitalization.Words,
-            focusDirection = FocusDirection.Right,
+            focusDirection = FocusDirection.Down,
             imeAction = ImeAction.Next,
             value = uiState.name,
             isError = uiState.nameError.isNotEmpty(),
@@ -192,7 +192,8 @@ fun SignupContainer(
             isError = uiState.passwordError.isNotEmpty(),
             errorLabel = uiState.passwordError,
             onValueChange = onChangePassword,
-            imeAction = ImeAction.Done
+            imeAction = ImeAction.Done,
+            onImeActionClick = onSignupClick,
         )
         Spacer(modifier = Modifier.height(24.dp))
         PrimaryButton(


### PR DESCRIPTION
## 📌 Title  
[BOC] Add action when Ime Action is clicked on InputFieldText

---

## 📝 Description  
When the form shows the last field with focus activided the user shows Done action in the keyboard, Now user can click on this option and this to close the keyboard and execute the setted action.

---

## 🔄 Changes  
- Added ** Ime Action is clicked on keyboard and Ime Action is Done
- Added ** Hide keyboard when Ime Action is Done and user click on Ime Action Done option

---

## 🎨 UI 

### Login
![login](https://github.com/user-attachments/assets/541486a6-b0ca-4189-a508-698c20f357d5)


### SignUp
![singin](https://github.com/user-attachments/assets/d5d50055-6484-4c74-a2cc-fb57c9691d36)


