### PR TITLE
feature: Add user data from google provider

### DIFF
--- a/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/data/datasources/AuthenticationDataSource.android.kt
+++ b/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/data/datasources/AuthenticationDataSource.android.kt
@@ -45,7 +45,10 @@ class AndroidAuthRemoteDataSource(val context: Context) : AuthenticationDataSour
                 .await()
 
             authResult.user?.let { user ->
-                UserAuthResponse(uid = user.uid)
+                UserAuthResponse(
+                    uid = user.uid,
+                    isNewUser = authResult.additionalUserInfo?.isNewUser ?: false
+                )
             } ?: UserAuthResponse(errorCode = "UNKNOWN_ERROR", errorMessage = "User is null.")
         } catch (ex: Exception) {
             UserAuthResponse(errorCode = "UNKNOWN_ERROR", errorMessage = ex.localizedMessage)

--- a/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/presentation/login/providers/GoogleAuthProvider.android.kt
+++ b/composeApp/src/androidMain/kotlin/us/docbee/docbeeapp/presentation/login/providers/GoogleAuthProvider.android.kt
@@ -9,9 +9,10 @@ import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import org.koin.core.context.GlobalContext
 import us.docbee.docbeeapp.BuildConfig
 import us.docbee.docbeeapp.domain.mappers.GoogleAuthErrorCodesMapper
+import us.docbee.docbeeapp.domain.models.login.AuthenticationModel
 
 class AndroidGoogleAuthProvider(private val context: Context) : GoogleAuthProvider {
-    override suspend fun getGoogleIdToken(): GoogleAuthResult {
+    override suspend fun getGoogleAuthData(): GoogleAuthResult {
         return try {
             val googleIdOption = GetSignInWithGoogleOption
                 .Builder(BuildConfig.SERVER_CLIENT_ID)
@@ -26,7 +27,15 @@ class AndroidGoogleAuthProvider(private val context: Context) : GoogleAuthProvid
 
             val credential = result.credential
             if (credential is CustomCredential && credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
-                GoogleAuthResult.Success(GoogleIdTokenCredential.createFrom(credential.data).idToken)
+                val googleData = GoogleIdTokenCredential.createFrom(credential.data)
+                GoogleAuthResult.Success(
+                    user = AuthenticationModel(
+                        idToken = googleData.idToken,
+                        name = googleData.givenName ?: "",
+                        lastname = googleData.familyName ?: "",
+                        email = googleData.id
+                    )
+                )
             } else {
                 GoogleAuthResult.Error
             }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/entities/UserAuthResponse.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/entities/UserAuthResponse.kt
@@ -2,6 +2,7 @@ package us.docbee.docbeeapp.data.entities
 
 data class UserAuthResponse(
     val uid: String? = null,
+    val isNewUser: Boolean = false,
     val errorCode: String? = null,
     val errorMessage: String? = null
 )

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/strategy/GoogleLoginStrategy.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/data/strategy/GoogleLoginStrategy.kt
@@ -1,31 +1,52 @@
 package us.docbee.docbeeapp.data.strategy
 
 import us.docbee.docbeeapp.data.datasources.AuthenticationDataSource
+import us.docbee.docbeeapp.data.datasources.UserRemoteDataSource
 import us.docbee.docbeeapp.domain.mappers.AuthErrorCodesMapper
+import us.docbee.docbeeapp.domain.models.login.AuthenticationModel
 import us.docbee.docbeeapp.domain.models.login.LoginParams
 import us.docbee.docbeeapp.domain.models.login.LoginResult
+import us.docbee.docbeeapp.domain.models.user.UserProfile
 import us.docbee.docbeeapp.domain.strategy.LoginStrategy
 import us.docbee.docbeeapp.presentation.login.providers.GoogleAuthProvider
 import us.docbee.docbeeapp.presentation.login.providers.GoogleAuthResult
+import kotlin.time.Clock
 
 class GoogleLoginStrategy(
     private val googleAuthProvider: GoogleAuthProvider,
-    private val authenticationDataSource: AuthenticationDataSource
-): LoginStrategy {
+    private val authenticationDataSource: AuthenticationDataSource,
+    private val userDataSource: UserRemoteDataSource
+) : LoginStrategy {
     override suspend fun login(credentials: LoginParams): LoginResult {
-        return when (val tokenResult = googleAuthProvider.getGoogleIdToken()) {
+        return when (val googleData = googleAuthProvider.getGoogleAuthData()) {
             is GoogleAuthResult.Cancelled -> LoginResult.CancelOperation
             is GoogleAuthResult.Error -> LoginResult.Error
-            is GoogleAuthResult.Success -> authenticate(tokenResult.idToken)
+            is GoogleAuthResult.Success -> authenticate(googleData.user)
         }
     }
 
-    private suspend fun authenticate(token: String): LoginResult {
-        val response = authenticationDataSource.authenticate(token)
+    private suspend fun authenticate(data: AuthenticationModel): LoginResult {
+        val response = authenticationDataSource.authenticate(data.idToken)
         return if (response.uid != null) {
+            createProfile(uid = response.uid, isNewUser = response.isNewUser, data = data)
             LoginResult.Success(response.uid)
         } else {
             AuthErrorCodesMapper.eval(error = response.errorCode)
         }
+    }
+
+    private suspend fun createProfile(uid: String, isNewUser: Boolean, data: AuthenticationModel) {
+        if (!isNewUser) return
+        userDataSource.saveUser(
+            UserProfile(
+                uid = uid,
+                name = data.name,
+                lastname = data.lastname,
+                email = data.email,
+                phoneNumber = data.phoneNumber,
+                dateOfBirth = "",
+                createdAt = Clock.System.now().toEpochMilliseconds()
+            )
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/di/DI.kt
@@ -87,7 +87,7 @@ val dataSourcesModule = module {
 
 val strategiesModule = module {
     factory { EmailLoginStrategy(get()) }
-    factory { GoogleLoginStrategy(get(), get()) }
+    factory { GoogleLoginStrategy(get(), get(), get()) }
     factory { AppleLoginStrategy() }
     factory { LoginStrategyFactory(get(), get(), get()) }
 }

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/login/AuthenticationModel.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/domain/models/login/AuthenticationModel.kt
@@ -1,0 +1,9 @@
+package us.docbee.docbeeapp.domain.models.login
+
+data class AuthenticationModel(
+    val idToken: String = "",
+    val name: String = "",
+    val lastname: String = "",
+    val email: String = "",
+    val phoneNumber: String = ""
+)

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/providers/GoogleAuthProvider.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/providers/GoogleAuthProvider.kt
@@ -1,7 +1,7 @@
 package us.docbee.docbeeapp.presentation.login.providers
 
 interface GoogleAuthProvider {
-    suspend fun getGoogleIdToken(): GoogleAuthResult
+    suspend fun getGoogleAuthData(): GoogleAuthResult
 }
 
 expect fun getGoogleAuthProvider(): GoogleAuthProvider

--- a/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/providers/GoogleAuthResult.kt
+++ b/composeApp/src/commonMain/kotlin/us/docbee/docbeeapp/presentation/login/providers/GoogleAuthResult.kt
@@ -1,7 +1,9 @@
 package us.docbee.docbeeapp.presentation.login.providers
 
+import us.docbee.docbeeapp.domain.models.login.AuthenticationModel
+
 sealed class GoogleAuthResult {
-    data class Success(val idToken: String): GoogleAuthResult()
+    data class Success(val user: AuthenticationModel): GoogleAuthResult()
     data object Cancelled: GoogleAuthResult()
     data object Error: GoogleAuthResult()
 }

--- a/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/data/datasources/AuthenticationDataSource.ios.kt
+++ b/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/data/datasources/AuthenticationDataSource.ios.kt
@@ -32,7 +32,10 @@ class IosAuthenticationDataSource() : AuthenticationDataSource {
         return suspendCancellableCoroutine<UserAuthResponse> { thread ->
             userAuthentication.signInWithIdToken(idToken = idToken) { result, error ->
                 val authResponse = if (result != null) {
-                    UserAuthResponse(uid = result["uid"].toString())
+                    UserAuthResponse(
+                        uid = result["uid"].toString(),
+                        isNewUser = result["isNewUser"].toString().toBoolean()
+                    )
                 } else {
                     val errorCode = error?.userInfo?.get("FIRAuthErrorUserInfoNameKey") as? String
                     val errorMessage = error?.userInfo?.get("NSLocalizedDescription") as? String

--- a/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/presentation/login/providers/GoogleAuthProvider.ios.kt
+++ b/composeApp/src/iosMain/kotlin/us/docbee/docbeeapp/presentation/login/providers/GoogleAuthProvider.ios.kt
@@ -3,6 +3,7 @@ package us.docbee.docbeeapp.presentation.login.providers
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.suspendCancellableCoroutine
 import us.docbee.docbeeapp.domain.mappers.GoogleAuthErrorCodesMapper
+import us.docbee.docbeeapp.domain.models.login.AuthenticationModel
 import us.docbee.docbeeapp.wrappers.GoogleAuthRemoteProvider
 
 @OptIn(ExperimentalForeignApi::class)
@@ -10,11 +11,12 @@ class IosGoogleAuthProvider: GoogleAuthProvider {
 
     private val googleAuthProvider = GoogleAuthRemoteProvider()
 
-    override suspend fun getGoogleIdToken(): GoogleAuthResult {
-        return suspendCancellableCoroutine<GoogleAuthResult> { thread ->
-            googleAuthProvider.getGoogleIdTokenWithCompletion { result, error ->
-                val response = if (!result.isNullOrEmpty()) {
-                    GoogleAuthResult.Success(result)
+    @Suppress("CAST_NEVER_SUCCEEDS")
+    override suspend fun getGoogleAuthData(): GoogleAuthResult {
+        return suspendCancellableCoroutine { thread ->
+            googleAuthProvider.getGoogleAuthDataWithCompletion { result, error ->
+                val response = if (result != null) {
+                    GoogleAuthResult.Success(result as AuthenticationModel )
                 } else {
                     val errorMessage = error?.userInfo?.get("NSLocalizedDescription") as? String
                     GoogleAuthErrorCodesMapper.eval(errorMessage)

--- a/iosApp/iosApp/Wrappers/GoogleAuthProvider.swift
+++ b/iosApp/iosApp/Wrappers/GoogleAuthProvider.swift
@@ -8,12 +8,13 @@
 import Foundation
 import UIKit
 import GoogleSignIn
+import ComposeApp
 
 
 @objc(GoogleAuthRemoteProvider)
 class GoogleAuthRemoteProvider: NSObject {
     
-    @objc func getGoogleIdToken(completion: @escaping (String?, Error?) -> Void) {
+    @objc func getGoogleAuthData(completion: @escaping (_ result: AuthenticationModel?, _ error: Error?) -> Void) {
         Task {
             do {
                 let token = try await getGoogleIdToken()
@@ -31,9 +32,9 @@ class GoogleAuthRemoteProvider: NSObject {
         return scene?.windows.first { $0.isKeyWindow }?.rootViewController
     }
     
-    private func getGoogleIdToken() async throws -> String {
+    private func getGoogleIdToken() async throws -> AuthenticationModel {
         guard let topViewController = await activeViewController else {
-            return ""
+            throw NSError(domain: "UI not configured", code: 0, userInfo: nil)
         }
 
         return try await withCheckedThrowingContinuation { continuation in
@@ -42,9 +43,16 @@ class GoogleAuthRemoteProvider: NSObject {
                     continuation.resume(throwing: error)
                     return
                 }
-                
-                let idToken = result?.user.idToken?.tokenString ?? ""
-                continuation.resume(returning: idToken)
+                let user = result?.user
+                let profile = user?.profile
+                let userModel = AuthenticationModel(
+                    idToken: user?.idToken?.tokenString ?? "",
+                    name: profile?.givenName ?? "",
+                    lastname: profile?.familyName ?? "",
+                    email: profile?.email ?? "",
+                    phoneNumber: ""
+                )
+                continuation.resume(returning: userModel)
             }
         }
     }

--- a/iosApp/iosApp/Wrappers/Interops/GoogleAuthProvider.h
+++ b/iosApp/iosApp/Wrappers/Interops/GoogleAuthProvider.h
@@ -10,7 +10,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface GoogleAuthRemoteProvider : NSObject
-- (void)getGoogleIdTokenWithCompletion:(void (^)(NSString * _Nullable, NSError * _Nullable))completion;
+- (void)getGoogleAuthDataWithCompletion:(void (^)(NSObject * _Nullable, NSError * _Nullable))completion;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iosApp/iosApp/Wrappers/UserRemoteAuthentication.swift
+++ b/iosApp/iosApp/Wrappers/UserRemoteAuthentication.swift
@@ -32,7 +32,8 @@ public class UserRemoteAuthentication: NSObject {
             guard self != nil else { return }
             if let user = authResult?.user {
                 let userInfo: [String: Any] = [
-                    "uid": user.uid
+                    "uid": user.uid,
+                    "isNewUser": authResult?.additionalUserInfo?.isNewUser ?? false,
                 ]
                 completion(userInfo as NSDictionary, nil)
             } else {


### PR DESCRIPTION
## 📌 Title  
Store Google Authenticated User Data in Firestore  

---

## 📝 Description  
This PR adds the logic to retrieve user information from the **Google authentication provider** after a successful login.  
The retrieved user data is then **stored in Firestore**, ensuring consistent user profiles across sessions and devices.  
